### PR TITLE
feat: 대회 및 부문 관련 컨트롤러, DTO 추가 및 AppModule에 통합

### DIFF
--- a/server/src/http/app.module.ts
+++ b/server/src/http/app.module.ts
@@ -1,10 +1,16 @@
 import { MiddlewareConsumer, Module, RequestMethod } from "@nestjs/common";
 
 import di from "@/container";
-import { ActorService, ActorSessionService } from "@/core/services";
+import {
+  ActorService,
+  ActorSessionService,
+  CompetitionService,
+} from "@/core/services";
 
 import { ActorController } from "./controllers/actor.controller";
 import { ActorSessionMiddleware } from "./middlewares/actor-session.middleware";
+import { CompetitionController } from "./controllers/competition.controller";
+import { DivisionController } from "./controllers/division.controller";
 
 type CustomProvider<T> = {
   provide: string;
@@ -20,10 +26,14 @@ const actorSessionService: CustomProvider<ActorSessionService> = {
   provide: "ActorSessionService",
   useValue: di.services.actorSession,
 };
+const competitionService: CustomProvider<CompetitionService> = {
+  provide: "CompetitionService",
+  useValue: di.services.competition,
+};
 
 @Module({
-  controllers: [ActorController],
-  providers: [actorService, actorSessionService],
+  controllers: [ActorController, CompetitionController, DivisionController],
+  providers: [actorService, actorSessionService, competitionService],
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {

--- a/server/src/http/controllers/competition.controller.ts
+++ b/server/src/http/controllers/competition.controller.ts
@@ -1,0 +1,158 @@
+import { Actor } from "@/core/models";
+import { CompetitionService } from "@/core/services";
+
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Inject,
+  Param,
+  Patch,
+  Post,
+} from "@nestjs/common";
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+
+import {
+  ApiActorSecurity,
+  CurrentActor,
+} from "../decorators/current-actor.decorator";
+import {
+  CompetitionResponseDto,
+  CreateCompetitionDto,
+  UpdateCompetitionDto,
+} from "../dtos/competition.dto";
+import { CreateDivisionDto, DivisionResponseDto } from "../dtos/division.dto";
+
+@ApiTags("Competitions")
+@Controller("competitions")
+export class CompetitionController {
+  constructor(
+    @Inject("CompetitionService")
+    private readonly competitionService: CompetitionService
+  ) {}
+
+  @Get("/")
+  @ApiResponse({
+    status: 200,
+    description: "모든 대회 목록 반환",
+    type: [CompetitionResponseDto],
+  })
+  async getCompetitions(@CurrentActor() actor: Actor) {
+    return this.competitionService.getCompetitions(actor);
+  }
+
+  @Get("/:competitionId")
+  @ApiResponse({
+    status: 200,
+    description: "대회 정보 반환",
+    type: CompetitionResponseDto,
+  })
+  async getCompetition(
+    @CurrentActor() actor: Actor,
+    @Param("competitionId") competitionId: string
+  ): Promise<CompetitionResponseDto> {
+    const { competition } =
+      await this.competitionService.getCompetitionWithDivisions(
+        actor,
+        competitionId
+      );
+    return competition;
+  }
+
+  @Post("/")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "대회 생성 성공 및 생성된 대회 정보 반환",
+    type: CompetitionResponseDto,
+  })
+  async createCompetition(
+    @CurrentActor() actor: Actor,
+    @Body() body: CreateCompetitionDto
+  ): Promise<CompetitionResponseDto> {
+    const { name, description } = body;
+    const competition = await this.competitionService.createCompetition(
+      actor,
+      name,
+      description
+    );
+    return competition;
+  }
+
+  @Patch("/:competitionId")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 200,
+    description: "대회 정보 수정 성공 및 수정된 대회 정보 반환",
+    type: UpdateCompetitionDto,
+  })
+  async updateCompetition(
+    @CurrentActor() actor: Actor,
+    @Param("competitionId") competitionId: string,
+    @Body() body: UpdateCompetitionDto
+  ): Promise<CompetitionResponseDto> {
+    const updated = await this.competitionService.updateCompetition(
+      actor,
+      competitionId,
+      body
+    );
+    return updated;
+  }
+
+  @Delete("/:competitionId")
+  @HttpCode(204)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 204,
+    description: "대회 삭제 성공",
+  })
+  async deleteCompetition(
+    @CurrentActor() actor: Actor,
+    @Param("competitionId") competitionId: string
+  ): Promise<void> {
+    await this.competitionService.deleteCompetition(actor, competitionId);
+  }
+
+  @Get("/:competitionId/divisions")
+  @ApiResponse({
+    status: 200,
+    description: "대회에 속한 모든 부문 목록 반환",
+    type: [DivisionResponseDto],
+  })
+  async getDivisions(
+    @CurrentActor() actor: Actor,
+    @Param("competitionId") competitionId: string
+  ): Promise<DivisionResponseDto[]> {
+    const { divisions } =
+      await this.competitionService.getCompetitionWithDivisions(
+        actor,
+        competitionId
+      );
+    return divisions;
+  }
+
+  @Post("/:competitionId/divisions")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "대회 부문 생성 성공",
+    type: DivisionResponseDto,
+  })
+  async createDivision(
+    @CurrentActor() actor: Actor,
+    @Param("competitionId") competitionId: string,
+    @Body() body: CreateDivisionDto
+  ) {
+    const division = await this.competitionService.createDivision(
+      actor,
+      competitionId,
+      body.name,
+      body.description
+    );
+    return division;
+  }
+}

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -1,0 +1,84 @@
+import { CompetitionService } from "@/core/services";
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  Inject,
+  Param,
+  Patch,
+} from "@nestjs/common";
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import {
+  ApiActorSecurity,
+  CurrentActor,
+} from "../decorators/current-actor.decorator";
+import {
+  DivisionResponseDto,
+  SetDivisionStatusDto,
+  UpdateDivisionDto,
+} from "../dtos/division.dto";
+import { Actor } from "@/core/models";
+
+@ApiTags("Divisions")
+@Controller("divisions")
+export class DivisionController {
+  constructor(
+    @Inject("CompetitionService")
+    private readonly competitionService: CompetitionService
+  ) {}
+
+  @Patch("/:divisionId")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 200,
+    description: "대회 부문 정보 수정 성공 및 대회 부문 정보 반환",
+    type: UpdateDivisionDto,
+  })
+  async updateDivision(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string,
+    @Body() body: UpdateDivisionDto
+  ): Promise<DivisionResponseDto> {
+    const updated = await this.competitionService.updateDivision(
+      actor,
+      divisionId,
+      body
+    );
+    return updated;
+  }
+
+  @Delete("/:divisionId")
+  @HttpCode(204)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 204,
+    description: "대회 부문 삭제 성공",
+  })
+  async deleteDivision(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string
+  ): Promise<void> {
+    await this.competitionService.deleteDivision(actor, divisionId);
+  }
+
+  @Patch("/:divisionId/status")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 200,
+    description: "대회 부문 상태 수정 성공 및 대회 부문 정보 반환",
+    type: DivisionResponseDto,
+  })
+  async setDivisionStatus(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string,
+    @Body() body: SetDivisionStatusDto
+  ): Promise<DivisionResponseDto> {
+    const updated = await this.competitionService.setDivisionStatus(
+      actor,
+      divisionId,
+      body.status
+    );
+    return updated;
+  }
+}

--- a/server/src/http/dtos/competition.dto.ts
+++ b/server/src/http/dtos/competition.dto.ts
@@ -44,7 +44,6 @@ export class UpdateCompetitionDto {
     example: "멍때리기는 뇌를 쉬게 해준대요.",
   })
   @IsString()
-  @IsNotEmpty()
   @IsOptional()
   description?: string;
 }

--- a/server/src/http/dtos/competition.dto.ts
+++ b/server/src/http/dtos/competition.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+export class CompetitionResponseDto {
+  @ApiProperty({ description: "대회 ID" })
+  id!: string;
+
+  @ApiProperty({ description: "대회 이름", example: "제0회 멍때리기 대회" })
+  name!: string;
+
+  @ApiProperty({
+    description: "대회 설명",
+    example: "멍때리기는 뇌를 쉬게 해준대요.",
+  })
+  description!: string;
+
+  @ApiProperty({ description: "대회 생성 시각", format: "date-time" })
+  createdAt!: Date;
+}
+
+export class CreateCompetitionDto {
+  @ApiProperty({ description: "대회 이름", example: "제0회 멍때리기 대회" })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description: "대회 설명",
+    example: "멍때리기는 뇌를 쉬게 해준대요.",
+  })
+  @IsString()
+  @IsNotEmpty()
+  description!: string;
+}
+
+export class UpdateCompetitionDto {
+  @ApiProperty({ description: "대회 이름", example: "제0회 멍때리기 대회" })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: "대회 설명",
+    example: "멍때리기는 뇌를 쉬게 해준대요.",
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  description?: string;
+}

--- a/server/src/http/dtos/division.dto.ts
+++ b/server/src/http/dtos/division.dto.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsOptional, IsIn } from "class-validator";
+
+const StatusTypes = ["ready", "ongoing", "closed"] as const;
+
+export class DivisionResponseDto {
+  @ApiProperty({ description: "대회 부문 ID" })
+  id!: string;
+
+  @ApiProperty({ description: "연결된 대회 ID" })
+  competitionId!: string;
+
+  @ApiProperty({ description: "대회 부문 이름", example: "Expert-DC 본선" })
+  name!: string;
+
+  @ApiProperty({
+    description: "대회 부문 설명",
+    example: "멍때리면서 DC 모터 라인트레이서를 굴려보세요!",
+  })
+  description!: string;
+
+  @ApiProperty({ description: "대회 부문 생성 시각", format: "date-time" })
+  createdAt!: Date;
+
+  @ApiProperty({
+    description: "대회 부문 상태",
+    type: String,
+    enum: StatusTypes,
+  })
+  status!: (typeof StatusTypes)[number];
+}
+
+export class CreateDivisionDto {
+  @ApiProperty({ description: "대회 부문 이름", example: "Expert-DC 본선" })
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description: "대회 부문 설명",
+    example: "멍때리면서 DC 모터 라인트레이서를 굴려보세요!",
+  })
+  @IsNotEmpty()
+  description!: string;
+}
+
+export class UpdateDivisionDto {
+  @ApiProperty({ description: "대회 부문 이름", example: "Expert-DC 본선" })
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: "대회 부문 설명",
+    example: "멍때리면서 DC 모터 라인트레이서를 굴려보세요!",
+  })
+  @IsOptional()
+  description?: string;
+}
+
+export class SetDivisionStatusDto {
+  @ApiProperty({
+    description: "대회 부문 상태",
+    type: String,
+    enum: StatusTypes,
+  })
+  @IsIn(StatusTypes)
+  status!: (typeof StatusTypes)[number];
+}

--- a/server/src/http/dtos/division.dto.ts
+++ b/server/src/http/dtos/division.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional, IsIn } from "class-validator";
+import { IsIn, IsNotEmpty, IsOptional, IsString } from "class-validator";
 
 const StatusTypes = ["ready", "ongoing", "closed"] as const;
 
@@ -32,6 +32,7 @@ export class DivisionResponseDto {
 
 export class CreateDivisionDto {
   @ApiProperty({ description: "대회 부문 이름", example: "Expert-DC 본선" })
+  @IsString()
   @IsNotEmpty()
   name!: string;
 
@@ -39,12 +40,14 @@ export class CreateDivisionDto {
     description: "대회 부문 설명",
     example: "멍때리면서 DC 모터 라인트레이서를 굴려보세요!",
   })
+  @IsString()
   @IsNotEmpty()
   description!: string;
 }
 
 export class UpdateDivisionDto {
   @ApiProperty({ description: "대회 부문 이름", example: "Expert-DC 본선" })
+  @IsString()
   @IsOptional()
   name?: string;
 
@@ -52,6 +55,7 @@ export class UpdateDivisionDto {
     description: "대회 부문 설명",
     example: "멍때리면서 DC 모터 라인트레이서를 굴려보세요!",
   })
+  @IsString()
   @IsOptional()
   description?: string;
 }


### PR DESCRIPTION
Closes #16 

## 변경 사항
- 아래의 API를 추가했습니다.
  - GET `/competitions`: 모든 대회 조회
  - POST `/competitions`: 대회 생성
  - GET `/competitions/{competitionId}`: 대회 조회
  - PATCH `/competitions/{competitionId}`: 대회 수정
  - DELETE `/competitions/{competitionId}`: 대회 삭제
  - GET `/competitions/{competitionId}/divisions`: 대회에 속한 부문 모두 조회
  - POST `/competitions/{competitionId}/division`: 대회에 부문 생성
  - PATCH `/divisions/{divisionId}`: 부문 수정
  - DELETE `/divisions/{divisionId}`: 부문 삭제
  - PATCH `/divisions/{divisionId}/status`: 부문 상태 변경
- 자세한 내용(요청 및 응답)은 swagger 참고 바람!