### PR TITLE
참가자 서비스에 필요한 레포지토리 레이어 구현

### DIFF
--- a/server/src/repositories/manual-record-sqlite.ts
+++ b/server/src/repositories/manual-record-sqlite.ts
@@ -1,0 +1,156 @@
+import { EntityNotFoundError, PersistenceError } from "@/core/errors";
+import { ManualRecord } from "@/core/models";
+import { ManualRecordRepository } from "@/core/repositories";
+
+import { SQLiteDatabaseAsyncWrapper } from "@/utils/sqlite";
+import sqlite3 from "sqlite3";
+
+type ManualRecordRecord = {
+  id: string;
+  participantId: string;
+  value: number;
+  recorderName: string;
+  createdAt: string;
+  invalidatedAt: string | null;
+  isDeleted: number;
+};
+
+export class ManualRecordSQLiteRepository implements ManualRecordRepository {
+  private db: SQLiteDatabaseAsyncWrapper;
+
+  constructor(db: sqlite3.Database) {
+    this.db = new SQLiteDatabaseAsyncWrapper(db);
+  }
+
+  async initialize(): Promise<ManualRecordRepository> {
+    try {
+      await this.db.run(
+        `CREATE TABLE IF NOT EXISTS manual_records (
+          id TEXT PRIMARY KEY NOT NULL,
+          participantId TEXT NOT NULL,
+          value INTEGER NOT NULL,
+          recorderName TEXT NOT NULL,
+          createdAt TEXT NOT NULL,
+          invalidatedAt TEXT,
+          isDeleted INTEGER NOT NULL
+        )`
+      );
+      await this.db.run(
+        // index [participantId, createdAt]
+        `CREATE INDEX IF NOT EXISTS idx_manual_records_participantId_createdAt
+          ON manual_records (participantId, createdAt)`
+      );
+    } catch (err) {
+      throw new PersistenceError(
+        `Failed to initialize ManualRecord database: ${err}`
+      );
+    }
+    return this;
+  }
+
+  private recordToEntity(record: ManualRecordRecord): ManualRecord {
+    return {
+      id: record.id,
+      participantId: record.participantId,
+      value: record.value,
+      recorderName: record.recorderName,
+      createdAt: new Date(record.createdAt),
+      invalidatedAt: record.invalidatedAt
+        ? new Date(record.invalidatedAt)
+        : null,
+    };
+  }
+
+  async getById(id: string): Promise<ManualRecord> {
+    const row = await this.db
+      .get<ManualRecordRecord>(
+        `SELECT * FROM manual_records WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get manual record by id '${id}': ${err}`
+        );
+      });
+    if (!row) {
+      throw new EntityNotFoundError(`ManualRecord with id '${id}' not found`);
+    }
+    return this.recordToEntity(row);
+  }
+
+  async create(manualRecord: ManualRecord): Promise<ManualRecord> {
+    await this.db
+      .run(
+        `INSERT INTO manual_records (id, participantId, value, recorderName, createdAt, invalidatedAt, isDeleted)
+          VALUES (?, ?, ?, ?, ?, ?, 0)`,
+        [
+          manualRecord.id,
+          manualRecord.participantId,
+          manualRecord.value,
+          manualRecord.recorderName,
+          manualRecord.createdAt.toISOString(),
+          manualRecord.invalidatedAt?.toISOString() || null,
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to create ManualRecord: ${err}`);
+      });
+    return manualRecord;
+  }
+
+  async update(manualRecord: ManualRecord): Promise<ManualRecord> {
+    const result = await this.db
+      .run(
+        `UPDATE manual_records
+          SET participantId = ?, value = ?, recorderName = ?, createdAt = ?, invalidatedAt = ?
+          WHERE id = ? AND isDeleted = 0`,
+        [
+          manualRecord.participantId,
+          manualRecord.value,
+          manualRecord.recorderName,
+          manualRecord.createdAt.toISOString(),
+          manualRecord.invalidatedAt?.toISOString() || null,
+          manualRecord.id,
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to update ManualRecord: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(
+        `ManualRecord with ID ${manualRecord.id} not found`
+      );
+    }
+    return manualRecord;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.db
+      .run(
+        `UPDATE manual_records SET isDeleted = 1 WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to delete ManualRecord: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(`ManualRecord with ID ${id} not found`);
+    }
+  }
+
+  async getByParticipantId(participantId: string): Promise<ManualRecord[]> {
+    const rows = await this.db
+      .all<ManualRecordRecord>(
+        `SELECT * FROM manual_records
+          WHERE participantId = ? AND isDeleted = 0
+          ORDER BY createdAt ASC`,
+        [participantId]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get manual records by participantId '${participantId}': ${err}`
+        );
+      });
+    return rows.map((row) => this.recordToEntity(row));
+  }
+}

--- a/server/src/repositories/participant-sqlite.ts
+++ b/server/src/repositories/participant-sqlite.ts
@@ -162,7 +162,7 @@ export class ParticipantSQLiteRepository implements ParticipantRepository {
       )
       .catch((err) => {
         throw new PersistenceError(
-          `Failed to get participants by divisionId '${divisionId}': ${err.message}`
+          `Failed to get participants by divisionId '${divisionId}': ${err}`
         );
       });
     return rows.map((row) => this.recordToEntity(row));

--- a/server/src/repositories/participant-sqlite.ts
+++ b/server/src/repositories/participant-sqlite.ts
@@ -1,0 +1,170 @@
+import { EntityNotFoundError, PersistenceError } from "@/core/errors";
+import { Participant } from "@/core/models";
+import { ParticipantRepository } from "@/core/repositories";
+
+import { SQLiteDatabaseAsyncWrapper } from "@/utils/sqlite";
+import sqlite3 from "sqlite3";
+
+type ParticipantRecord = {
+  id: string;
+  divisionId: string;
+  name: string;
+  teamName: string;
+  robotName: string;
+  comment: string;
+  orderRaw: number;
+  givenTime: number;
+  createdAt: string;
+  isDeleted: number;
+};
+
+export class ParticipantSQLiteRepository implements ParticipantRepository {
+  private db: SQLiteDatabaseAsyncWrapper;
+
+  constructor(db: sqlite3.Database) {
+    this.db = new SQLiteDatabaseAsyncWrapper(db);
+  }
+
+  async initialize(): Promise<ParticipantRepository> {
+    try {
+      await this.db.run(
+        `CREATE TABLE IF NOT EXISTS participants (
+          id TEXT PRIMARY KEY NOT NULL,
+          divisionId TEXT NOT NULL,
+          name TEXT NOT NULL,
+          teamName TEXT NOT NULL,
+          robotName TEXT NOT NULL,
+          comment TEXT NOT NULL,
+          orderRaw INTEGER NOT NULL,
+          givenTime INTEGER NOT NULL,
+          createdAt TEXT NOT NULL,
+          isDeleted INTEGER NOT NULL
+        )`
+      );
+      await this.db.run(
+        // index [divisionId, orderRaw]
+        `CREATE INDEX IF NOT EXISTS idx_participants_divisionId_orderRaw
+          ON participants (divisionId, orderRaw)`
+      );
+    } catch (err) {
+      throw new PersistenceError(
+        `Failed to initialize Participant database: ${err}`
+      );
+    }
+    return this;
+  }
+
+  private recordToEntity(record: ParticipantRecord): Participant {
+    return {
+      id: record.id,
+      divisionId: record.divisionId,
+      name: record.name,
+      teamName: record.teamName,
+      robotName: record.robotName,
+      comment: record.comment,
+      orderRaw: record.orderRaw,
+      givenTime: record.givenTime,
+      createdAt: new Date(record.createdAt),
+    };
+  }
+
+  async getById(id: string): Promise<Participant> {
+    const row = await this.db
+      .get<ParticipantRecord>(
+        `SELECT * FROM participants
+          WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get participant by id '${id}': ${err}`
+        );
+      });
+    if (!row) {
+      throw new EntityNotFoundError(`Participant with id '${id}' not found`);
+    }
+    return this.recordToEntity(row);
+  }
+
+  async create(participant: Participant): Promise<Participant> {
+    await this.db
+      .run(
+        `INSERT INTO participants (id, divisionId, name, teamName, robotName, comment, orderRaw, givenTime, createdAt, isDeleted)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+        [
+          participant.id,
+          participant.divisionId,
+          participant.name,
+          participant.teamName,
+          participant.robotName,
+          participant.comment,
+          participant.orderRaw,
+          participant.givenTime,
+          participant.createdAt.toISOString(),
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to create Participant: ${err}`);
+      });
+    return participant;
+  }
+
+  async update(participant: Participant): Promise<Participant> {
+    const result = await this.db
+      .run(
+        `UPDATE participants
+          SET divisionId = ?, name = ?, teamName = ?, robotName = ?, comment = ?, orderRaw = ?, givenTime = ?, createdAt = ?
+          WHERE id = ? AND isDeleted = 0`,
+        [
+          participant.divisionId,
+          participant.name,
+          participant.teamName,
+          participant.robotName,
+          participant.comment,
+          participant.orderRaw,
+          participant.givenTime,
+          participant.createdAt.toISOString(),
+          participant.id,
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to update Participant: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(
+        `Participant with ID ${participant.id} not found`
+      );
+    }
+    return participant;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.db
+      .run(
+        `UPDATE participants SET isDeleted = 1 WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to delete Participant: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(`Participant with ID ${id} not found`);
+    }
+  }
+
+  async getByDivisionId(divisionId: string): Promise<Participant[]> {
+    const rows = await this.db
+      .all<ParticipantRecord>(
+        `SELECT * FROM participants
+          WHERE divisionId = ? AND isDeleted = 0
+          ORDER BY orderRaw ASC`,
+        [divisionId]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get participants by divisionId '${divisionId}': ${err.message}`
+        );
+      });
+    return rows.map((row) => this.recordToEntity(row));
+  }
+}

--- a/server/src/repositories/record-sqlite.ts
+++ b/server/src/repositories/record-sqlite.ts
@@ -1,0 +1,156 @@
+import { EntityNotFoundError, PersistenceError } from "@/core/errors";
+import { Record } from "@/core/models";
+import { RecordRepository } from "@/core/repositories";
+
+import { SQLiteDatabaseAsyncWrapper } from "@/utils/sqlite";
+import sqlite3 from "sqlite3";
+
+type RecordRecord = {
+  id: string;
+  participantId: string;
+  value: number;
+  source: string;
+  status: string;
+  note: string;
+  createdAt: string;
+  isDeleted: number;
+};
+
+export class RecordSQLiteRepository implements RecordRepository {
+  private db: SQLiteDatabaseAsyncWrapper;
+
+  constructor(db: sqlite3.Database) {
+    this.db = new SQLiteDatabaseAsyncWrapper(db);
+  }
+
+  async initialize(): Promise<RecordRepository> {
+    try {
+      await this.db.run(
+        `CREATE TABLE IF NOT EXISTS records (
+          id TEXT PRIMARY KEY NOT NULL,
+          participantId TEXT NOT NULL,
+          value INTEGER NOT NULL,
+          source TEXT NOT NULL,
+          status TEXT NOT NULL,
+          note TEXT NOT NULL,
+          createdAt TEXT NOT NULL,
+          isDeleted INTEGER NOT NULL
+        )`
+      );
+      await this.db.run(
+        // index [participantId, createdAt]
+        `CREATE INDEX IF NOT EXISTS idx_records_participantId_createdAt
+          ON records (participantId, createdAt)`
+      );
+    } catch (err) {
+      throw new PersistenceError(
+        `Failed to initialize Record database: ${err}`
+      );
+    }
+    return this;
+  }
+
+  private recordToEntity(record: RecordRecord): Record {
+    return {
+      id: record.id,
+      participantId: record.participantId,
+      value: record.value,
+      source: record.source as Record["source"],
+      status: record.status as Record["status"],
+      note: record.note,
+      createdAt: new Date(record.createdAt),
+    };
+  }
+
+  async getById(id: string): Promise<Record> {
+    const row = await this.db
+      .get<RecordRecord>(
+        `SELECT * FROM records WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get record by id '${id}': ${err}`
+        );
+      });
+    if (!row) {
+      throw new EntityNotFoundError(`Record with id '${id}' not found`);
+    }
+    return this.recordToEntity(row);
+  }
+
+  async create(record: Record): Promise<Record> {
+    await this.db
+      .run(
+        `INSERT INTO records (id, participantId, value, source, status, note, createdAt, isDeleted)
+          VALUES (?, ?, ?, ?, ?, ?, ?, 0)`,
+        [
+          record.id,
+          record.participantId,
+          record.value,
+          record.source,
+          record.status,
+          record.note,
+          record.createdAt.toISOString(),
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to create Record: ${err}`);
+      });
+    return record;
+  }
+
+  async update(record: Record): Promise<Record> {
+    const result = await this.db
+      .run(
+        `UPDATE records
+          SET participantId = ?, value = ?, source = ?, status = ?, note = ?, createdAt = ?
+          WHERE id = ? AND isDeleted = 0`,
+        [
+          record.participantId,
+          record.value,
+          record.source,
+          record.status,
+          record.note,
+          record.createdAt.toISOString(),
+          record.id,
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to update Record: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(`Record with ID ${record.id} not found`);
+    }
+    return record;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.db
+      .run(`UPDATE records SET isDeleted = 1 WHERE id = ? AND isDeleted = 0`, [
+        id,
+      ])
+      .catch((err) => {
+        throw new PersistenceError(`Failed to delete Record: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(`Record with ID ${id} not found`);
+    }
+  }
+
+  async getByParticipantId(participantId: string): Promise<Record[]> {
+    const rows = await this.db
+      .all<RecordRecord>(
+        `SELECT * FROM records
+          WHERE participantId = ? AND isDeleted = 0
+          ORDER BY createdAt ASC`,
+        [participantId]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get records by participantId '${participantId}': ${err}`
+        );
+      });
+    return rows.map((row) => this.recordToEntity(row));
+  }
+}

--- a/server/src/repositories/timer-log-sqlite.ts
+++ b/server/src/repositories/timer-log-sqlite.ts
@@ -1,0 +1,149 @@
+import { EntityNotFoundError, PersistenceError } from "@/core/errors";
+import { TimerLog } from "@/core/models";
+import { TimerLogRepository } from "@/core/repositories";
+
+import { SQLiteDatabaseAsyncWrapper } from "@/utils/sqlite";
+import sqlite3 from "sqlite3";
+
+type TimerLogRecord = {
+  id: string;
+  participantId: string;
+  value: number;
+  type: string;
+  createdAt: string;
+  isDeleted: number;
+};
+
+export class TimerLogSQLiteRepository implements TimerLogRepository {
+  private db: SQLiteDatabaseAsyncWrapper;
+
+  constructor(db: sqlite3.Database) {
+    this.db = new SQLiteDatabaseAsyncWrapper(db);
+  }
+
+  async initialize(): Promise<TimerLogRepository> {
+    try {
+      await this.db.run(
+        `CREATE TABLE IF NOT EXISTS timer_logs (
+          id TEXT PRIMARY KEY NOT NULL,
+          participantId TEXT NOT NULL,
+          value INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          createdAt TEXT NOT NULL,
+          isDeleted INTEGER NOT NULL
+        )`
+      );
+      await this.db.run(
+        // index [participantId, createdAt] for efficient querying by participant
+        `CREATE INDEX IF NOT EXISTS idx_timer_logs_participantId_createdAt
+          ON timer_logs (participantId, createdAt)`
+      );
+    } catch (err) {
+      throw new PersistenceError(
+        `Failed to initialize TimerLog database: ${err}`
+      );
+    }
+    return this;
+  }
+
+  private recordToEntity(record: TimerLogRecord): TimerLog {
+    return {
+      id: record.id,
+      participantId: record.participantId,
+      value: record.value,
+      type: record.type as TimerLog["type"],
+      createdAt: new Date(record.createdAt),
+    };
+  }
+
+  async getById(id: string): Promise<TimerLog> {
+    const row = await this.db
+      .get<TimerLogRecord>(
+        `SELECT * FROM timer_logs WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get timer log by id '${id}': ${err}`
+        );
+      });
+    if (!row) {
+      throw new EntityNotFoundError(`TimerLog with id '${id}' not found`);
+    }
+    return this.recordToEntity(row);
+  }
+
+  async create(timerLog: TimerLog): Promise<TimerLog> {
+    await this.db
+      .run(
+        `INSERT INTO timer_logs (id, participantId, value, type, createdAt, isDeleted)
+          VALUES (?, ?, ?, ?, ?, 0)`,
+        [
+          timerLog.id,
+          timerLog.participantId,
+          timerLog.value,
+          timerLog.type,
+          timerLog.createdAt.toISOString(),
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to create TimerLog: ${err}`);
+      });
+    return timerLog;
+  }
+
+  async update(timerLog: TimerLog): Promise<TimerLog> {
+    const result = await this.db
+      .run(
+        `UPDATE timer_logs
+          SET participantId = ?, value = ?, type = ?, createdAt = ?
+          WHERE id = ? AND isDeleted = 0`,
+        [
+          timerLog.participantId,
+          timerLog.value,
+          timerLog.type,
+          timerLog.createdAt.toISOString(),
+          timerLog.id,
+        ]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to update TimerLog: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(
+        `TimerLog with ID ${timerLog.id} not found`
+      );
+    }
+    return timerLog;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.db
+      .run(
+        `UPDATE timer_logs SET isDeleted = 1 WHERE id = ? AND isDeleted = 0`,
+        [id]
+      )
+      .catch((err) => {
+        throw new PersistenceError(`Failed to delete TimerLog: ${err}`);
+      });
+    if (result.changes === 0) {
+      throw new EntityNotFoundError(`TimerLog with ID ${id} not found`);
+    }
+  }
+
+  async getByParticipantId(participantId: string): Promise<TimerLog[]> {
+    const rows = await this.db
+      .all<TimerLogRecord>(
+        `SELECT * FROM timer_logs
+          WHERE participantId = ? AND isDeleted = 0
+          ORDER BY createdAt ASC`,
+        [participantId]
+      )
+      .catch((err) => {
+        throw new PersistenceError(
+          `Failed to get timer logs by participantId '${participantId}': ${err}`
+        );
+      });
+    return rows.map((row) => this.recordToEntity(row));
+  }
+}

--- a/server/src/repositories/timer-log-sqlite.ts
+++ b/server/src/repositories/timer-log-sqlite.ts
@@ -9,7 +9,7 @@ type TimerLogRecord = {
   id: string;
   participantId: string;
   value: number;
-  type: string;
+  logType: string;
   createdAt: string;
   isDeleted: number;
 };
@@ -28,7 +28,7 @@ export class TimerLogSQLiteRepository implements TimerLogRepository {
           id TEXT PRIMARY KEY NOT NULL,
           participantId TEXT NOT NULL,
           value INTEGER NOT NULL,
-          type TEXT NOT NULL,
+          logType TEXT NOT NULL,
           createdAt TEXT NOT NULL,
           isDeleted INTEGER NOT NULL
         )`
@@ -51,7 +51,7 @@ export class TimerLogSQLiteRepository implements TimerLogRepository {
       id: record.id,
       participantId: record.participantId,
       value: record.value,
-      type: record.type as TimerLog["type"],
+      type: record.logType as TimerLog["type"],
       createdAt: new Date(record.createdAt),
     };
   }
@@ -76,7 +76,7 @@ export class TimerLogSQLiteRepository implements TimerLogRepository {
   async create(timerLog: TimerLog): Promise<TimerLog> {
     await this.db
       .run(
-        `INSERT INTO timer_logs (id, participantId, value, type, createdAt, isDeleted)
+        `INSERT INTO timer_logs (id, participantId, value, logType, createdAt, isDeleted)
           VALUES (?, ?, ?, ?, ?, 0)`,
         [
           timerLog.id,
@@ -96,7 +96,7 @@ export class TimerLogSQLiteRepository implements TimerLogRepository {
     const result = await this.db
       .run(
         `UPDATE timer_logs
-          SET participantId = ?, value = ?, type = ?, createdAt = ?
+          SET participantId = ?, value = ?, logType = ?, createdAt = ?
           WHERE id = ? AND isDeleted = 0`,
         [
           timerLog.participantId,

--- a/server/tests/integration/repositories/manual-record-sqlite.test.ts
+++ b/server/tests/integration/repositories/manual-record-sqlite.test.ts
@@ -1,0 +1,14 @@
+import { ManualRecordSQLiteRepository } from "@/repositories/manual-record-sqlite";
+import { runManualRecordRepositoryContract } from "@tests/shared/repositories/manual-record.contract";
+
+import sqlite3 from "sqlite3";
+
+runManualRecordRepositoryContract(
+  //
+  "ManualRecordSQLiteRepository 통합 테스트",
+  async () => {
+    const db = new sqlite3.Database(":memory:");
+    const repo = new ManualRecordSQLiteRepository(db);
+    return await repo.initialize();
+  }
+);

--- a/server/tests/integration/repositories/participant-sqlite.test.ts
+++ b/server/tests/integration/repositories/participant-sqlite.test.ts
@@ -1,0 +1,14 @@
+import { ParticipantSQLiteRepository } from "@/repositories/participant-sqlite";
+import { runParticipantRepositoryContract } from "@tests/shared/repositories/participant.contract";
+
+import sqlite3 from "sqlite3";
+
+runParticipantRepositoryContract(
+  //
+  "ParticipantSQLiteRepository 통합 테스트",
+  async () => {
+    const db = new sqlite3.Database(":memory:");
+    const repo = new ParticipantSQLiteRepository(db);
+    return await repo.initialize();
+  }
+);

--- a/server/tests/integration/repositories/record-sqlite.test.ts
+++ b/server/tests/integration/repositories/record-sqlite.test.ts
@@ -1,0 +1,14 @@
+import { RecordSQLiteRepository } from "@/repositories/record-sqlite";
+import { runRecordRepositoryContract } from "@tests/shared/repositories/record.contract";
+
+import sqlite3 from "sqlite3";
+
+runRecordRepositoryContract(
+  //
+  "RecordSQLiteRepository 통합 테스트",
+  async () => {
+    const db = new sqlite3.Database(":memory:");
+    const repo = new RecordSQLiteRepository(db);
+    return await repo.initialize();
+  }
+);

--- a/server/tests/integration/repositories/timer-log-sqlite.test.ts
+++ b/server/tests/integration/repositories/timer-log-sqlite.test.ts
@@ -1,0 +1,14 @@
+import { TimerLogSQLiteRepository } from "@/repositories/timer-log-sqlite";
+import { runTimerLogRepositoryContract } from "@tests/shared/repositories/timer-log.contract";
+
+import sqlite3 from "sqlite3";
+
+runTimerLogRepositoryContract(
+  //
+  "TimerLogSQLiteRepository 통합 테스트",
+  async () => {
+    const db = new sqlite3.Database(":memory:");
+    const repo = new TimerLogSQLiteRepository(db);
+    return await repo.initialize();
+  }
+);

--- a/server/tests/shared/repositories/manual-record.contract.ts
+++ b/server/tests/shared/repositories/manual-record.contract.ts
@@ -1,0 +1,117 @@
+import { ManualRecord } from "@/core/models";
+import { ManualRecordRepository } from "@/core/repositories";
+import { EntityNotFoundError } from "@/core/errors";
+
+import { v4 as uuidv4 } from "uuid";
+
+export function runManualRecordRepositoryContract(
+  name: string,
+  make: () => Promise<ManualRecordRepository>,
+  cleanup?: () => Promise<void>
+) {
+  describe(name, () => {
+    let repo: ManualRecordRepository;
+
+    beforeAll(async () => {
+      repo = await make();
+    });
+
+    afterAll(async () => {
+      if (cleanup) {
+        await cleanup();
+      }
+    });
+
+    function createEntity(participantId?: string): ManualRecord {
+      return {
+        id: `test-${uuidv4()}`,
+        participantId: participantId ?? `test-${uuidv4()}`,
+        value: Math.floor(Math.random() * 10000),
+        recorderName: "테스트 계수자",
+        createdAt: new Date(),
+        invalidatedAt: null,
+      };
+    }
+
+    it("수동 기록 엔티티를 저장하고 불러올 수 있다.", async () => {
+      const entity = createEntity();
+      await repo.create(entity);
+      const loaded = await repo.getById(entity.id);
+
+      expect(loaded).toEqual(entity);
+    });
+
+    it("특정 참가자에 대해 여러 수동 기록들을 저장하고 불러올 수 있다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: ManualRecord[] = [];
+      for (let i = 0; i < 5; i++) {
+        entities.push(createEntity(participantId));
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      expect(loaded).toHaveLength(entities.length);
+      for (const entity of entities) {
+        expect(loaded).toContainEqual(entity);
+      }
+    });
+
+    it("수동 기록 엔티티를 수정할 수 있다.", async () => {
+      const original = createEntity();
+      await repo.create(original);
+      const updated: ManualRecord = {
+        ...original,
+        value: 100000,
+        recorderName: "수정된 계수자",
+        invalidatedAt: new Date(),
+      };
+      await repo.update(updated);
+      const loaded = await repo.getById(original.id);
+
+      expect(loaded).toEqual(updated);
+    });
+
+    it("수동 기록 엔티티를 삭제할 수 있고, 해당 엔티티에 접근할 수 없다.", async () => {
+      const entity = createEntity();
+      await repo.create(entity);
+      await repo.delete(entity.id);
+      const loaded = await repo.getByParticipantId(entity.participantId);
+
+      expect(loaded).not.toContainEqual(entity);
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("존재하지 않는 수동 기록 엔티티에 접근하면 오류가 발생한다.", async () => {
+      const entity = createEntity();
+
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("특정 참가자의 수동 기록들이 생성 시간 순서대로 정렬되어 반환된다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: ManualRecord[] = [];
+      const now = new Date();
+      for (let factor of [0, 3, 2, 1]) {
+        const entity = createEntity(participantId);
+        entity.createdAt = new Date(now.getTime() + factor * 1000);
+        entities.push(entity);
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      // createdAt 순서대로 정렬되어야 함
+      const sortedEntities = [...entities].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+      expect(loaded.map((c) => c.id)).toEqual(sortedEntities.map((c) => c.id));
+    });
+  });
+}

--- a/server/tests/shared/repositories/participant.contract.ts
+++ b/server/tests/shared/repositories/participant.contract.ts
@@ -1,0 +1,114 @@
+import { Participant } from "@/core/models";
+import { ParticipantRepository } from "@/core/repositories";
+import { EntityNotFoundError } from "@/core/errors";
+
+import { v4 as uuidv4 } from "uuid";
+
+export function runParticipantRepositoryContract(
+  name: string,
+  make: () => Promise<ParticipantRepository>,
+  cleanup?: () => Promise<void>
+) {
+  describe(name, () => {
+    let repo: ParticipantRepository;
+
+    beforeAll(async () => {
+      repo = await make();
+    });
+
+    afterAll(async () => {
+      if (cleanup) {
+        await cleanup();
+      }
+    });
+
+    function createEntity(order: number, divisionId?: string): Participant {
+      return {
+        id: `test-${uuidv4()}`,
+        divisionId: divisionId ?? `test-${uuidv4()}`,
+        name: `테스트 참가자 ${order}`,
+        teamName: `테스트 팀 ${order}`,
+        robotName: `테스트 로봇 ${order}`,
+        comment: `테스트 참가자 ${order}의 코멘트`,
+        orderRaw: order,
+        givenTime: 4 * 60 * 1000, // 4분
+        createdAt: new Date(),
+      };
+    }
+
+    it("참가자 엔티티를 저장하고 불러올 수 있다.", async () => {
+      const entity = createEntity(1);
+      await repo.create(entity);
+      const loaded = await repo.getById(entity.id);
+
+      expect(loaded).toEqual(entity);
+    });
+
+    it("특정 부문에 대해 여러 참가자들을 저장하고 불러올 수 있다.", async () => {
+      const divisionId = `test-${uuidv4()}`;
+      const entities: Participant[] = [];
+      for (let i = 0; i < 5; i++) {
+        entities.push(createEntity(i, divisionId));
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByDivisionId(divisionId);
+
+      expect(loaded).toHaveLength(entities.length);
+      expect(loaded).toEqual(entities);
+    });
+
+    it("참가자 엔티티를 수정할 수 있다.", async () => {
+      const original = createEntity(1);
+      await repo.create(original);
+      const updated: Participant = {
+        ...original,
+        name: "수정된 참가자 이름",
+        teamName: "수정된 팀 이름",
+        robotName: "수정된 로봇 이름",
+        comment: "수정된 참가자 코멘트",
+        orderRaw: 999,
+        givenTime: 5 * 60 * 1000, // 5분
+      };
+      await repo.update(updated);
+      const loaded = await repo.getById(original.id);
+
+      expect(loaded).toEqual(updated);
+    });
+
+    it("참가자 엔티티를 삭제할 수 있고, 해당 엔티티에 접근할 수 없다.", async () => {
+      const entity = createEntity(1);
+      await repo.create(entity);
+      await repo.delete(entity.id);
+      const loaded = await repo.getByDivisionId(entity.divisionId);
+
+      expect(loaded).not.toContainEqual(entity);
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("존재하지 않는 참가자 엔티티에 접근하면 오류가 발생한다.", async () => {
+      const entity = createEntity(1);
+
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("특정 부문의 참가자들이 경연 순서대로 정렬되어 반환된다.", async () => {
+      const orders = [4, 1, 3, 2];
+      const divisionId = `test-${uuidv4()}`;
+      const entities = orders.map((order) => createEntity(order, divisionId));
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByDivisionId(divisionId);
+
+      // orderRaw 순서대로 정렬되어야 함
+      const targetOrders = [...orders].sort((a, b) => a - b);
+      expect(loaded.map((c) => c.orderRaw)).toEqual(targetOrders);
+    });
+  });
+}

--- a/server/tests/shared/repositories/record.contract.ts
+++ b/server/tests/shared/repositories/record.contract.ts
@@ -1,0 +1,119 @@
+import { Record } from "@/core/models";
+import { RecordRepository } from "@/core/repositories";
+import { EntityNotFoundError } from "@/core/errors";
+
+import { v4 as uuidv4 } from "uuid";
+
+export function runRecordRepositoryContract(
+  name: string,
+  make: () => Promise<RecordRepository>,
+  cleanup?: () => Promise<void>
+) {
+  describe(name, () => {
+    let repo: RecordRepository;
+
+    beforeAll(async () => {
+      repo = await make();
+    });
+
+    afterAll(async () => {
+      if (cleanup) {
+        await cleanup();
+      }
+    });
+
+    function createEntity(participantId?: string): Record {
+      return {
+        id: `test-${uuidv4()}`,
+        participantId: participantId ?? `test-${uuidv4()}`,
+        value: Math.floor(Math.random() * 10000),
+        source: "stopwatch" as const,
+        status: "pending" as const,
+        note: "여기는 비고란",
+        createdAt: new Date(),
+      };
+    }
+
+    it("기록 엔티티를 저장하고 불러올 수 있다.", async () => {
+      const entity = createEntity();
+      await repo.create(entity);
+      const loaded = await repo.getById(entity.id);
+
+      expect(loaded).toEqual(entity);
+    });
+
+    it("특정 참가자에 대해 여러 기록들을 저장하고 불러올 수 있다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: Record[] = [];
+      for (let i = 0; i < 5; i++) {
+        entities.push(createEntity(participantId));
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      expect(loaded).toHaveLength(entities.length);
+      for (const entity of entities) {
+        expect(loaded).toContainEqual(entity);
+      }
+    });
+
+    it("기록 엔티티를 수정할 수 있다.", async () => {
+      const original = createEntity();
+      await repo.create(original);
+      const updated: Record = {
+        ...original,
+        value: 100000,
+        source: "manual" as const,
+        status: "approved" as const,
+        note: "수정된 기록 비고",
+      };
+      await repo.update(updated);
+      const loaded = await repo.getById(original.id);
+
+      expect(loaded).toEqual(updated);
+    });
+
+    it("기록 엔티티를 삭제할 수 있고, 해당 엔티티에 접근할 수 없다.", async () => {
+      const entity = createEntity();
+      await repo.create(entity);
+      await repo.delete(entity.id);
+      const loaded = await repo.getByParticipantId(entity.participantId);
+
+      expect(loaded).not.toContainEqual(entity);
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("존재하지 않는 기록 엔티티에 접근하면 오류가 발생한다.", async () => {
+      const entity = createEntity();
+
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("특정 참가자의 기록들이 생성 시간 순서대로 정렬되어 반환된다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: Record[] = [];
+      const now = new Date();
+      for (let factor of [0, 3, 2, 1]) {
+        const entity = createEntity(participantId);
+        entity.createdAt = new Date(now.getTime() + factor * 1000);
+        entities.push(entity);
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      // createdAt 순서대로 정렬되어야 함
+      const sortedEntities = [...entities].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+      expect(loaded.map((c) => c.id)).toEqual(sortedEntities.map((c) => c.id));
+    });
+  });
+}

--- a/server/tests/shared/repositories/timer-log.contract.ts
+++ b/server/tests/shared/repositories/timer-log.contract.ts
@@ -1,0 +1,127 @@
+import { TimerLog } from "@/core/models";
+import { TimerLogRepository } from "@/core/repositories";
+import { EntityNotFoundError } from "@/core/errors";
+
+import { v4 as uuidv4 } from "uuid";
+
+export function runTimerLogRepositoryContract(
+  name: string,
+  make: () => Promise<TimerLogRepository>,
+  cleanup?: () => Promise<void>
+) {
+  describe(name, () => {
+    let repo: TimerLogRepository;
+
+    beforeAll(async () => {
+      repo = await make();
+    });
+
+    afterAll(async () => {
+      if (cleanup) {
+        await cleanup();
+      }
+    });
+
+    const logTypes: TimerLog["type"][] = ["start", "stop", "add", "sub"];
+
+    function createEntity(order: number, participantId?: string): TimerLog {
+      const logType = logTypes[order % logTypes.length];
+      let value = Date.now();
+      if (logType === "stop") {
+        value = Date.now() + 10000; // 10초 뒤
+      } else if (logType === "add") {
+        value = 3000; // 3초 추가
+      } else if (logType === "sub") {
+        value = 1000; // 1초 삭감
+      }
+
+      return {
+        id: `test-${uuidv4()}`,
+        participantId: participantId ?? `test-${uuidv4()}`,
+        value,
+        type: logType,
+        createdAt: new Date(),
+      };
+    }
+
+    it("타이머 로그 엔티티를 저장하고 불러올 수 있다.", async () => {
+      const entity = createEntity(0);
+      await repo.create(entity);
+      const loaded = await repo.getById(entity.id);
+
+      expect(loaded).toEqual(entity);
+    });
+
+    it("특정 참가자에 대해 여러 타이머 로그들을 저장하고 불러올 수 있다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: TimerLog[] = [];
+      for (let i = 0; i < 5; i++) {
+        entities.push(createEntity(i, participantId));
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      expect(loaded).toHaveLength(entities.length);
+      for (const entity of entities) {
+        expect(loaded).toContainEqual(entity);
+      }
+    });
+
+    it("타이머 로그 엔티티를 수정할 수 있다.", async () => {
+      const original = createEntity(0);
+      await repo.create(original);
+      const updated: TimerLog = {
+        ...original,
+        value: 2000,
+        type: "add",
+      };
+      await repo.update(updated);
+      const loaded = await repo.getById(original.id);
+
+      expect(loaded).toEqual(updated);
+    });
+
+    it("타이머 로그 엔티티를 삭제할 수 있고, 해당 엔티티에 접근할 수 없다.", async () => {
+      const entity = createEntity(0);
+      await repo.create(entity);
+      await repo.delete(entity.id);
+      const loaded = await repo.getByParticipantId(entity.participantId);
+
+      expect(loaded).not.toContainEqual(entity);
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("존재하지 않는 타이머 로그 엔티티에 접근하면 오류가 발생한다.", async () => {
+      const entity = createEntity(0);
+
+      await expect(repo.getById(entity.id)).rejects.toThrow(
+        EntityNotFoundError
+      );
+      await expect(repo.update(entity)).rejects.toThrow(EntityNotFoundError);
+      await expect(repo.delete(entity.id)).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it("특정 참가자의 타이머 로그들이 생성 시각 순서대로 정렬되어 반환된다.", async () => {
+      const participantId = `test-${uuidv4()}`;
+      const entities: TimerLog[] = [];
+      const now = new Date();
+      for (let factor of [0, 2, 3, 1]) {
+        const entity = createEntity(factor, participantId);
+        entity.createdAt = new Date(now.getTime() + factor * 1000);
+        entities.push(entity);
+      }
+      await Promise.all(entities.map((c) => repo.create(c)));
+      const loaded = await repo.getByParticipantId(participantId);
+
+      // createdAt 순서대로 정렬되어야 함
+      const sortedEntities = [...entities].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+      expect(loaded.map((c) => c.id)).toEqual(sortedEntities.map((c) => c.id));
+    });
+  });
+}


### PR DESCRIPTION
Closes #19 

## 변경 사항
- `ParticipantSQLiteRepository` 및 테스트 코드 추가
- `RecordSQLiteRepository` 및 테스트 코드 추가
- `ManualRecordSQLiteRepository` 및 테스트 코드 추가
- `TimerLogSQLiteRepository` 및 테스트 코드 추가
- 위의 레포지토리들은 모두 참가자 서비스가 실제로 돌아가기 위해서 필요한 구현체들이다.

## 테스트
- server 디렉터리에서 `npm run test:integration` 실행해보면 됩니다.