### PR TITLE
Record 서비스 구현 및 컨트롤러 등록

### DIFF
--- a/server/src/container.ts
+++ b/server/src/container.ts
@@ -3,6 +3,7 @@ import {
   ActorSessionService,
   CompetitionService,
   ParticipantService,
+  RecordService,
 } from "@/core/services";
 
 import { ActorIdPwSQLiteRepository } from "@/repositories/actor-id-pw-sqlite";
@@ -10,11 +11,13 @@ import { ActorSQLiteRepository } from "@/repositories/actor-sqlite";
 import { CompetitionSQLiteRepository } from "@/repositories/competition-sqlite";
 import { DivisionSQLiteRepository } from "@/repositories/division-sqlite";
 import { ParticipantSQLiteRepository } from "@/repositories/participant-sqlite";
+import { RecordSQLiteRepository } from "@/repositories/record-sqlite";
 
 import { ActorServiceImpl } from "@/services/actor";
 import { ActorSessionRandomService } from "@/services/actor-session-random";
 import { CompetitionServiceImpl } from "@/services/competition";
 import { ParticipantServiceImpl } from "@/services/participant";
+import { RecordServiceImpl } from "@/services/record";
 
 import sqlite3 from "sqlite3";
 
@@ -49,12 +52,14 @@ export class Container {
   private readonly competitionSQLiteRepo: CompetitionSQLiteRepository;
   private readonly divisionSQLiteRepo: DivisionSQLiteRepository;
   private readonly participantSQLiteRepo: ParticipantSQLiteRepository;
+  private readonly recordSQLiteRepo: RecordSQLiteRepository;
 
   // Services
   private readonly actorService: ActorService;
   private readonly actorSessionService: ActorSessionService;
   private readonly competitionService: CompetitionService;
   private readonly participantService: ParticipantService;
+  private readonly recordService: RecordService;
 
   private constructor() {
     // SQLite Database
@@ -74,6 +79,7 @@ export class Container {
     this.competitionSQLiteRepo = new CompetitionSQLiteRepository(this.db);
     this.divisionSQLiteRepo = new DivisionSQLiteRepository(this.db);
     this.participantSQLiteRepo = new ParticipantSQLiteRepository(this.db);
+    this.recordSQLiteRepo = new RecordSQLiteRepository(this.db);
 
     this.actorService = new ActorServiceImpl({
       actorRepository: this.actorSQLiteRepo,
@@ -88,6 +94,10 @@ export class Container {
       divisionRepository: this.divisionSQLiteRepo,
     });
     this.participantService = new ParticipantServiceImpl({
+      participantRepository: this.participantSQLiteRepo,
+    });
+    this.recordService = new RecordServiceImpl({
+      recordRepository: this.recordSQLiteRepo,
       participantRepository: this.participantSQLiteRepo,
     });
   }
@@ -116,6 +126,7 @@ export class Container {
       this.actorSQLiteRepo.initialize(),
       this.actorIdPwSQLiteRepo.initialize(),
       this.participantSQLiteRepo.initialize(),
+      this.recordSQLiteRepo.initialize(),
     ]);
 
     this.initialized = true;
@@ -127,6 +138,7 @@ export class Container {
       actorSession: this.actorSessionService,
       competition: this.competitionService,
       participant: this.participantService,
+      record: this.recordService,
     };
   }
 }

--- a/server/src/core/services.ts
+++ b/server/src/core/services.ts
@@ -208,33 +208,29 @@ export interface RecordService {
   /**
    * 특정 참가자의 대회 기록을 조회할 수 있다.
    */
-  getRecords(actorId: string, participantId: string): Promise<Record[]>;
+  getRecords(actor: Actor, participantId: string): Promise<Record[]>;
 
   /**
    * 특정 참가자에 대회 기록을 추가할 수 있다.
    */
   addRecord(
-    actorId: string,
+    actor: Actor,
     participantId: string,
     value: number,
     source: Record["source"],
-    note?: string
+    note: string
   ): Promise<Record>;
 
   /**
    * 특정 참가자의 대회 기록에 비고란을 수정할 수 있다.
    */
-  setRecordNote(
-    actorId: string,
-    recordId: string,
-    note: string
-  ): Promise<Record>;
+  setRecordNote(actor: Actor, recordId: string, note: string): Promise<Record>;
 
   /**
    * 특정 참가자의 대회 기록의 상태(승인/거절)를 변경할 수 있다.
    */
   setRecordStatus(
-    actorId: string,
+    actor: Actor,
     recordId: string,
     status: Record["status"]
   ): Promise<Record>;
@@ -242,28 +238,18 @@ export interface RecordService {
   /**
    * 특정 부문의 상위 대회 기록을 조회할 수 있다.
    */
-  getTopRecordsByDivision(
-    actorId: string,
-    divisionId: string
-  ): Promise<Record[]>;
+  getTopRecordsByDivision(actor: Actor, divisionId: string): Promise<Record[]>;
 
   // -----------------------------
   // Observable 구독 관련 메서드들
   // -----------------------------
   /**
-   * 특정 참가자의 대회 기록 추가 이벤트를 구독할 수 있다.
+   * 특정 참가자의 기록 상태(승인/거절)가 변경된 경우를 구독할 수 있다.
+   * addRecord() 호출로 인한 기록 추가 또는 setRecordStatus() 호출로 인한 상태 변경 시에 이벤트가 발생한다.
    */
-  subscribeRecordAdded(
+  subscribeRecordStatusChanged(
     participantId: string,
-    callback: (record: Record) => void
-  ): Unsubscriber;
-
-  /**
-   * 특정 경연에서 경연자들의 최고 기록이 갱신됐을 때 구독할 수 있다.
-   */
-  subscribeTopRecordsUpdated(
-    divisionId: string,
-    callback: (records: Record[]) => void
+    callback: (record: Record) => Promise<void>
   ): Unsubscriber;
 }
 

--- a/server/src/http/app.module.ts
+++ b/server/src/http/app.module.ts
@@ -6,13 +6,15 @@ import {
   ActorSessionService,
   CompetitionService,
   ParticipantService,
+  RecordService,
 } from "@/core/services";
 
 import { ActorController } from "./controllers/actor.controller";
-import { ActorSessionMiddleware } from "./middlewares/actor-session.middleware";
 import { CompetitionController } from "./controllers/competition.controller";
 import { DivisionController } from "./controllers/division.controller";
 import { ParticipantController } from "./controllers/participant.controller";
+import { RecordController } from "./controllers/record.controller";
+import { ActorSessionMiddleware } from "./middlewares/actor-session.middleware";
 
 type CustomProvider<T> = {
   provide: string;
@@ -36,6 +38,10 @@ const participantService: CustomProvider<ParticipantService> = {
   provide: "ParticipantService",
   useValue: di.services.participant,
 };
+const recordService: CustomProvider<RecordService> = {
+  provide: "RecordService",
+  useValue: di.services.record,
+};
 
 @Module({
   controllers: [
@@ -43,12 +49,14 @@ const participantService: CustomProvider<ParticipantService> = {
     CompetitionController,
     DivisionController,
     ParticipantController,
+    RecordController,
   ],
   providers: [
     actorService,
     actorSessionService,
     competitionService,
     participantService,
+    recordService,
   ],
 })
 export class AppModule {

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -1,4 +1,10 @@
-import { CompetitionService, ParticipantService } from "@/core/services";
+import { Actor } from "@/core/models";
+import {
+  CompetitionService,
+  ParticipantService,
+  RecordService,
+} from "@/core/services";
+
 import {
   Body,
   Controller,
@@ -11,6 +17,7 @@ import {
   Post,
 } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
+
 import {
   ApiActorSecurity,
   CurrentActor,
@@ -21,10 +28,10 @@ import {
   UpdateDivisionDto,
 } from "../dtos/division.dto";
 import {
-  ParticipantResponseDto,
   CreateParticipantDto,
+  ParticipantResponseDto,
 } from "../dtos/participant.dto";
-import { Actor } from "@/core/models";
+import { RecordResponseDto } from "../dtos/record.dto";
 
 @ApiTags("Divisions")
 @Controller("divisions")
@@ -33,7 +40,9 @@ export class DivisionController {
     @Inject("CompetitionService")
     private readonly competitionService: CompetitionService,
     @Inject("ParticipantService")
-    private readonly participantService: ParticipantService
+    private readonly participantService: ParticipantService,
+    @Inject("RecordService")
+    private readonly recordService: RecordService
   ) {}
 
   @Patch("/:divisionId")
@@ -127,5 +136,18 @@ export class DivisionController {
       orderRaw,
       givenTime
     );
+  }
+
+  @Get("/:divisionId/top-records")
+  @ApiResponse({
+    status: 200,
+    description: "특정 부문의 상위 기록 목록 반환",
+    type: [RecordResponseDto],
+  })
+  async getTopRecordsByDivision(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string
+  ): Promise<RecordResponseDto[]> {
+    return this.recordService.getTopRecordsByDivision(actor, divisionId);
   }
 }

--- a/server/src/http/controllers/participant.controller.ts
+++ b/server/src/http/controllers/participant.controller.ts
@@ -1,14 +1,16 @@
 import { Actor } from "@/core/models";
-import { ParticipantService } from "@/core/services";
+import { ParticipantService, RecordService } from "@/core/services";
 
 import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   Inject,
   Param,
   Patch,
+  Post,
 } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 
@@ -20,13 +22,16 @@ import {
   ParticipantResponseDto,
   UpdateParticipantDto,
 } from "../dtos/participant.dto";
+import { AddRecordDto, RecordResponseDto } from "../dtos/record.dto";
 
 @ApiTags("Participants")
 @Controller("participants")
 export class ParticipantController {
   constructor(
     @Inject("ParticipantService")
-    private readonly participantService: ParticipantService
+    private readonly participantService: ParticipantService,
+    @Inject("RecordService")
+    private readonly recordService: RecordService
   ) {}
 
   @Patch("/:participantId")
@@ -60,5 +65,39 @@ export class ParticipantController {
     @Param("participantId") participantId: string
   ): Promise<void> {
     await this.participantService.deleteParticipant(actor, participantId);
+  }
+
+  @Get("/:participantId/records")
+  @ApiResponse({
+    status: 200,
+    description: "특정 참가자의 모든 기록 목록 반환",
+    type: [RecordResponseDto],
+  })
+  async getRecords(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string
+  ): Promise<RecordResponseDto[]> {
+    return this.recordService.getRecords(actor, participantId);
+  }
+
+  @Post("/:participantId/records")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "기록 추가 성공 및 추가된 기록 정보 반환",
+    type: RecordResponseDto,
+  })
+  async addRecord(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string,
+    @Body() body: AddRecordDto
+  ): Promise<RecordResponseDto> {
+    return this.recordService.addRecord(
+      actor,
+      participantId,
+      body.value,
+      body.source,
+      body.note
+    );
   }
 }

--- a/server/src/http/controllers/record.controller.ts
+++ b/server/src/http/controllers/record.controller.ts
@@ -1,7 +1,7 @@
 import { Actor } from "@/core/models";
 import { RecordService } from "@/core/services";
 
-import { Body, Controller, Get, Inject, Param, Patch } from "@nestjs/common";
+import { Body, Controller, Inject, Param, Patch } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import {
@@ -50,18 +50,5 @@ export class RecordController {
     @Body() body: SetRecordStatusDto
   ): Promise<RecordResponseDto> {
     return this.recordService.setRecordStatus(actor, recordId, body.status);
-  }
-
-  @Get("/divisions/:divisionId/top")
-  @ApiResponse({
-    status: 200,
-    description: "특정 부문의 상위 기록 목록 반환",
-    type: [RecordResponseDto],
-  })
-  async getTopRecordsByDivision(
-    @CurrentActor() actor: Actor,
-    @Param("divisionId") divisionId: string
-  ): Promise<RecordResponseDto[]> {
-    return this.recordService.getTopRecordsByDivision(actor, divisionId);
   }
 }

--- a/server/src/http/controllers/record.controller.ts
+++ b/server/src/http/controllers/record.controller.ts
@@ -1,0 +1,67 @@
+import { Actor } from "@/core/models";
+import { RecordService } from "@/core/services";
+
+import { Body, Controller, Get, Inject, Param, Patch } from "@nestjs/common";
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+
+import {
+  ApiActorSecurity,
+  CurrentActor,
+} from "../decorators/current-actor.decorator";
+import {
+  RecordResponseDto,
+  SetRecordNoteDto,
+  SetRecordStatusDto,
+} from "../dtos/record.dto";
+
+@ApiTags("Records")
+@Controller("records")
+export class RecordController {
+  constructor(
+    @Inject("RecordService")
+    private readonly recordService: RecordService
+  ) {}
+
+  @Patch("/:recordId/note")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 200,
+    description: "기록 비고 수정 성공 및 수정된 기록 정보 반환",
+    type: RecordResponseDto,
+  })
+  async setRecordNote(
+    @CurrentActor() actor: Actor,
+    @Param("recordId") recordId: string,
+    @Body() body: SetRecordNoteDto
+  ): Promise<RecordResponseDto> {
+    return this.recordService.setRecordNote(actor, recordId, body.note);
+  }
+
+  @Patch("/:recordId/status")
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 200,
+    description: "기록 상태 변경 성공 및 변경된 기록 정보 반환",
+    type: RecordResponseDto,
+  })
+  async setRecordStatus(
+    @CurrentActor() actor: Actor,
+    @Param("recordId") recordId: string,
+    @Body() body: SetRecordStatusDto
+  ): Promise<RecordResponseDto> {
+    return this.recordService.setRecordStatus(actor, recordId, body.status);
+  }
+
+  @Get("/divisions/:divisionId/top")
+  @ApiResponse({
+    status: 200,
+    description: "특정 부문의 상위 기록 목록 반환",
+    type: [RecordResponseDto],
+  })
+  async getTopRecordsByDivision(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string
+  ): Promise<RecordResponseDto[]> {
+    return this.recordService.getTopRecordsByDivision(actor, divisionId);
+  }
+}

--- a/server/src/http/dtos/record.dto.ts
+++ b/server/src/http/dtos/record.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty, IsNumber, IsString, Min } from "class-validator";
+
+export class RecordResponseDto {
+  @ApiProperty({ type: String, description: "기록 ID" })
+  id!: string;
+
+  @ApiProperty({ type: String, description: "참가자 ID" })
+  participantId!: string;
+
+  @ApiProperty({ type: Number, description: "기록 값", example: 1000 })
+  value!: number;
+
+  @ApiProperty({
+    type: String,
+    description: "기록 출처",
+    enum: ["stopwatch", "manual", "other"],
+    example: "stopwatch",
+  })
+  source!: "stopwatch" | "manual" | "other";
+
+  @ApiProperty({
+    type: String,
+    description: "기록 상태",
+    enum: ["pending", "approved", "rejected"],
+    example: "pending",
+  })
+  status!: "pending" | "approved" | "rejected";
+
+  @ApiProperty({ type: String, description: "비고", example: "테스트 기록" })
+  note!: string;
+
+  @ApiProperty({ type: String, description: "생성 시각", format: "date-time" })
+  createdAt!: Date;
+}
+
+export class AddRecordDto {
+  @ApiProperty({ type: Number, description: "기록 값", example: 1000 })
+  @IsNumber()
+  @Min(0)
+  value!: number;
+
+  @ApiProperty({
+    type: String,
+    description: "기록 출처",
+    enum: ["stopwatch", "manual", "other"],
+    example: "stopwatch",
+  })
+  @IsEnum(["stopwatch", "manual", "other"])
+  source!: "stopwatch" | "manual" | "other";
+
+  @ApiProperty({ type: String, description: "비고", example: "테스트 기록" })
+  @IsString()
+  @IsNotEmpty()
+  note!: string;
+}
+
+export class SetRecordNoteDto {
+  @ApiProperty({ type: String, description: "비고", example: "수정된 비고" })
+  @IsString()
+  @IsNotEmpty()
+  note!: string;
+}
+
+export class SetRecordStatusDto {
+  @ApiProperty({
+    type: String,
+    description: "기록 상태",
+    enum: ["pending", "approved", "rejected"],
+    example: "approved",
+  })
+  @IsEnum(["pending", "approved", "rejected"])
+  status!: "pending" | "approved" | "rejected";
+}

--- a/server/src/services/record.ts
+++ b/server/src/services/record.ts
@@ -1,0 +1,149 @@
+import { Actor, Record } from "@/core/models";
+import { ParticipantRepository, RecordRepository } from "@/core/repositories";
+import { RecordService, Unsubscriber } from "@/core/services";
+
+import { EventEmitter } from "events";
+import { v4 as uuidv4 } from "uuid";
+
+import { requireAnyRole } from "@/utils/auth";
+
+export class RecordServiceImpl implements RecordService {
+  private readonly recordRepo: RecordRepository;
+  private readonly participantRepo: ParticipantRepository;
+
+  constructor(di: {
+    recordRepository: RecordRepository;
+    participantRepository: ParticipantRepository;
+  }) {
+    this.recordRepo = di.recordRepository;
+    this.participantRepo = di.participantRepository;
+  }
+
+  async getRecords(actor: Actor, participantId: string): Promise<Record[]> {
+    return this.recordRepo.getByParticipantId(participantId);
+  }
+
+  async addRecord(
+    actor: Actor,
+    participantId: string,
+    value: number,
+    source: Record["source"],
+    note: string
+  ): Promise<Record> {
+    requireAnyRole(actor, "administrator", "stopwatchRecorder");
+
+    const record: Record = {
+      id: uuidv4(),
+      participantId,
+      value,
+      source,
+      status: "pending",
+      note,
+      createdAt: new Date(),
+    };
+    const result = await this.recordRepo.create(record);
+    this.emitRecordStatusChanged(result);
+    return result;
+  }
+
+  async setRecordNote(
+    actor: Actor,
+    recordId: string,
+    note: string
+  ): Promise<Record> {
+    requireAnyRole(actor, "administrator");
+
+    const record = await this.recordRepo.getById(recordId);
+    const updated = {
+      ...record,
+      note,
+    };
+    const result = await this.recordRepo.update(updated);
+    return result;
+  }
+
+  async setRecordStatus(
+    actor: Actor,
+    recordId: string,
+    status: Record["status"]
+  ): Promise<Record> {
+    requireAnyRole(actor, "administrator");
+
+    const record = await this.recordRepo.getById(recordId);
+    const updated = {
+      ...record,
+      status,
+    };
+    const result = await this.recordRepo.update(updated);
+    this.emitRecordStatusChanged(result);
+    return result;
+  }
+
+  /**
+   * 특정 부문의 상위 기록을 가져올 수 있어야 한다.
+   *
+   * 1. divisionId에 대한 참가자 목록을 조회한다. -> ParticipantRepository.getByDivisionId()
+   * 2. participantId에 대한 최고 기록을 조회한다. -> RecordRepository.getByParticipantId()
+   * 3. 승인된 기록 중 최고 기록을 찾는다. -> filter Record.status === "approved" && max(Record.value)
+   * 4. 참가자의 최고 기록을 오름차순으로 정렬한다.
+   */
+  async getTopRecordsByDivision(
+    actor: Actor,
+    divisionId: string
+  ): Promise<Record[]> {
+    // 해당 부문의 모든 참가자 조회
+    const participants = await this.participantRepo.getByDivisionId(divisionId);
+
+    // 각 참가자의 최고 기록을 찾는다.
+    const bestRecordByParticipant: Map<string, Record> = new Map();
+    for (const participant of participants) {
+      const records = await this.recordRepo.getByParticipantId(participant.id);
+      const bestRecord = records
+        .filter((record) => record.status === "approved")
+        .sort((a, b) => a.value - b.value);
+      if (bestRecord.length > 0) {
+        bestRecordByParticipant.set(participant.id, bestRecord[0]);
+      }
+    }
+
+    // 참가자의 최고 기록을 오름차순으로 정렬한다.
+    const bestRecords = Array.from(bestRecordByParticipant.values());
+    return bestRecords.sort((a, b) => a.value - b.value);
+  }
+
+  // ------------------------------
+  // 이벤트 핸들링 관련 로직
+  // ------------------------------
+  private eventEmitter = new EventEmitter();
+
+  private getRecordStatusChangedEventName = (participantId: string) =>
+    `record:status:changed:${participantId}`;
+
+  private emitRecordStatusChanged(record: Record) {
+    this.eventEmitter.emit(
+      this.getRecordStatusChangedEventName(record.participantId),
+      record
+    );
+  }
+
+  subscribeRecordStatusChanged(
+    participantId: string,
+    callback: (record: Record) => Promise<void>
+  ): Unsubscriber {
+    const eventName = this.getRecordStatusChangedEventName(participantId);
+    const safeCb = async (record: Record) => {
+      try {
+        await callback(record);
+      } catch (err) {
+        console.error(
+          `Record status changed listener error for ${participantId}:`,
+          err
+        );
+      }
+    };
+    this.eventEmitter.on(eventName, safeCb);
+    return () => {
+      this.eventEmitter.off(eventName, safeCb);
+    };
+  }
+}

--- a/server/tests/unit/services/record.test.ts
+++ b/server/tests/unit/services/record.test.ts
@@ -1,0 +1,339 @@
+import { AuthorizationError } from "@/core/errors";
+import { Actor, Participant, Record } from "@/core/models";
+import { ParticipantRepository, RecordRepository } from "@/core/repositories";
+
+import { RecordServiceImpl } from "@/services/record";
+
+import { v4 as uuidv4 } from "uuid";
+
+const mockRecordRepo: jest.Mocked<RecordRepository> = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getByParticipantId: jest.fn(),
+};
+
+const mockParticipantRepo: jest.Mocked<ParticipantRepository> = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getByDivisionId: jest.fn(),
+};
+
+const generateDummyRecord = (
+  participantId: string,
+  value: number = Math.floor(Math.random() * 10000)
+): Record => ({
+  id: uuidv4(),
+  participantId,
+  value,
+  source: "stopwatch" as const,
+  status: "pending" as const,
+  note: "테스트 기록",
+  createdAt: new Date(),
+});
+
+const generateDummyParticipant = (
+  divisionId: string,
+  name: string = "테스트 참가자"
+): Participant => ({
+  id: uuidv4(),
+  divisionId,
+  name,
+  teamName: "테스트 팀",
+  robotName: "테스트 로봇",
+  comment: "테스트 코멘트",
+  orderRaw: 1,
+  givenTime: 4 * 60 * 1000, // 4분
+  createdAt: new Date(),
+});
+
+describe("RecordService 구현체 단위 테스트", () => {
+  let service: RecordServiceImpl;
+  let adminActor: Actor;
+  let stopwatchRecorderActor: Actor;
+  let anonymousActor: Actor;
+
+  beforeAll(() => {
+    adminActor = {
+      id: uuidv4(),
+      name: "관리자",
+      roles: ["administrator"],
+      createdAt: new Date(),
+    };
+    stopwatchRecorderActor = {
+      id: uuidv4(),
+      name: "계수기",
+      roles: ["stopwatchRecorder"],
+      createdAt: new Date(),
+    };
+    anonymousActor = {
+      id: uuidv4(),
+      name: "익명 사용자",
+      roles: [],
+      createdAt: new Date(),
+    };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new RecordServiceImpl({
+      recordRepository: mockRecordRepo,
+      participantRepository: mockParticipantRepo,
+    });
+  });
+
+  it("아무나 특정 참가자의 기록을 조회할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const records: Record[] = [];
+    for (let i = 0; i < 5; i++) {
+      records.push(generateDummyRecord(participantId));
+    }
+    mockRecordRepo.getByParticipantId.mockResolvedValue(records);
+
+    // Act
+    const result = await service.getRecords(anonymousActor, participantId);
+
+    // Assert
+    expect(result).toEqual(records);
+  });
+
+  it("관리자와 계수기만 기록을 추가할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const record = generateDummyRecord(participantId);
+    mockRecordRepo.create.mockResolvedValue(record);
+
+    // Act & Assert - 익명 사용자는 권한 없음
+    await expect(
+      service.addRecord(
+        anonymousActor,
+        participantId,
+        record.value,
+        record.source,
+        record.note
+      )
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert - 관리자는 권한 있음
+    const adminResult = await service.addRecord(
+      adminActor,
+      participantId,
+      record.value,
+      record.source,
+      record.note
+    );
+    expect(adminResult).toEqual(record);
+
+    // Act & Assert - 계수기는 권한 있음
+    const recorderResult = await service.addRecord(
+      stopwatchRecorderActor,
+      participantId,
+      record.value,
+      record.source,
+      record.note
+    );
+    expect(recorderResult).toEqual(record);
+    expect(mockRecordRepo.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("관리자만 기록의 비고를 수정할 수 있다.", async () => {
+    // Arrange
+    const record = generateDummyRecord(uuidv4());
+    const updatedRecord = { ...record, note: "수정된 비고" };
+    mockRecordRepo.getById.mockResolvedValue(record);
+    mockRecordRepo.update.mockResolvedValue(updatedRecord);
+
+    // Act & Assert - 익명 사용자는 권한 없음
+    await expect(
+      service.setRecordNote(anonymousActor, record.id, "수정된 비고")
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert - 관리자는 권한 있음
+    const result = await service.setRecordNote(
+      adminActor,
+      record.id,
+      "수정된 비고"
+    );
+    expect(result).toEqual(updatedRecord);
+    expect(mockRecordRepo.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("관리자만 기록의 상태를 변경할 수 있다.", async () => {
+    // Arrange
+    const record = generateDummyRecord(uuidv4());
+    const updatedRecord = { ...record, status: "approved" as const };
+    mockRecordRepo.getById.mockResolvedValue(record);
+    mockRecordRepo.update.mockResolvedValue(updatedRecord);
+
+    // Act & Assert - 익명 사용자는 권한 없음
+    await expect(
+      service.setRecordStatus(anonymousActor, record.id, "approved")
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert - 관리자는 권한 있음
+    const result = await service.setRecordStatus(
+      adminActor,
+      record.id,
+      "approved"
+    );
+    expect(result).toEqual(updatedRecord);
+    expect(mockRecordRepo.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("특정 부문의 상위 기록을 조회할 수 있다.", async () => {
+    // arrange
+    const divisionId = uuidv4();
+    const mockParticipants = [
+      generateDummyParticipant(divisionId, "참가자1"),
+      generateDummyParticipant(divisionId, "참가자2"),
+    ];
+    mockParticipantRepo.getByDivisionId.mockResolvedValue(mockParticipants);
+    const mockRecords: Record[] = [
+      generateDummyRecord(mockParticipants[0].id, 13000),
+      generateDummyRecord(mockParticipants[0].id, 3000),
+      generateDummyRecord(mockParticipants[1].id, 1000),
+      generateDummyRecord(mockParticipants[1].id, 2000),
+    ].map((r) => ({ ...r, status: "approved" }));
+    mockRecords.push({
+      // 무효화된 기록은 상위 기록에 포함되지 않는다.
+      ...generateDummyRecord(mockParticipants[0].id, 1000),
+      status: "rejected",
+    });
+    mockRecordRepo.getByParticipantId.mockImplementation(
+      (participantId: string) => {
+        const records = mockRecords.filter(
+          (r) => r.participantId === participantId
+        );
+        return Promise.resolve(records);
+      }
+    );
+
+    // act
+    const result = await service.getTopRecordsByDivision(
+      adminActor,
+      divisionId
+    );
+
+    // assert
+    expect(result.map((r) => [r.participantId, r.value])).toEqual([
+      [mockParticipants[1].id, 1000],
+      [mockParticipants[0].id, 3000],
+    ]);
+  });
+
+  describe("참가자 기록 갱신 이벤트 구독 테스트", () => {
+    let participantId: string;
+    let callback1: jest.Mock;
+    let callback2: jest.Mock;
+    let callback1Unsubscriber: () => void;
+    let callback2Unsubscriber: () => void;
+
+    beforeEach(() => {
+      // Arrange
+      participantId = uuidv4();
+      callback1 = jest.fn();
+      callback2 = jest.fn();
+      callback1Unsubscriber = service.subscribeRecordStatusChanged(
+        participantId,
+        callback1
+      );
+      callback2Unsubscriber = service.subscribeRecordStatusChanged(
+        participantId,
+        callback2
+      );
+    });
+
+    afterEach(() => {
+      callback1Unsubscriber();
+      callback2Unsubscriber();
+      jest.clearAllMocks();
+    });
+
+    it("기록이 추가되었을 때 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const record = generateDummyRecord(participantId);
+      mockRecordRepo.create.mockResolvedValue(record);
+
+      // Act
+      await service.addRecord(
+        adminActor,
+        participantId,
+        record.value,
+        record.source,
+        record.note
+      );
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(record);
+      expect(callback2).toHaveBeenCalledWith(record);
+    });
+
+    it("기록 상태가 변경되었을 때 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const record = generateDummyRecord(participantId);
+      mockRecordRepo.getById.mockResolvedValue(record);
+      const updatedRecord = { ...record, status: "approved" as const };
+      mockRecordRepo.update.mockResolvedValue(updatedRecord);
+
+      // Act
+      await service.setRecordStatus(adminActor, record.id, "approved");
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(updatedRecord);
+      expect(callback2).toHaveBeenCalledWith(updatedRecord);
+    });
+
+    it("구독 함수에서 오류가 발생해도 서비스 로직은 정상적으로 동작한다.", async () => {
+      // Arrange
+      const record = generateDummyRecord(participantId);
+      mockRecordRepo.create.mockResolvedValue(record);
+      callback1.mockRejectedValue(
+        new Error("에러가 발생해도 서비스 로직은 정상적으로 동작해야 해요.")
+      );
+      const errorSpy = jest // 오류 메시지 출력 방지
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      // Act
+      const asyncTask = service.addRecord(
+        adminActor,
+        participantId,
+        record.value,
+        record.source,
+        record.note
+      );
+
+      // Assert
+      await expect(asyncTask).resolves.toBe(record);
+      expect(callback1).toHaveBeenCalledWith(record);
+      expect(callback2).toHaveBeenCalledWith(record);
+
+      // Cleanup
+      errorSpy.mockRestore();
+    });
+
+    it("구독을 해제하면 더 이상 이벤트를 받지 않는다.", async () => {
+      // Arrange
+      const record = generateDummyRecord(participantId);
+      mockRecordRepo.create.mockResolvedValue(record);
+      callback1Unsubscriber();
+
+      // Act
+      await service.addRecord(
+        adminActor,
+        participantId,
+        record.value,
+        record.source,
+        record.note
+      );
+
+      // Assert
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledWith(record);
+    });
+  });
+});


### PR DESCRIPTION
Closes #26 

## 변경 사항
- RecordService 인터페이스에서 actorId를 Actor 객체로 변경
- RecordService 인터페이스에서 `subscribeRecordAdded`, `subscribeTopRecordsUpdated`를 제거하고, 특정 참가자의 기록 상태 추가/변경을 구독하는 메서드를 두는 것으로 재설계
  - 특정 참가자의 기록 상태 추가/변경 이벤트가 발생하면 구독하는 측에서 해당 서비스에서 `getTopRecordsByDivision`를 호출하여 상태 전파 가능
  - 좀 더 넓은 범위로 이벤트 타입 설계
- RecordService 구현체 및 단위 테스트 코드 추가
- Record 관련 API Controller 추가
  - GET `/participants/{participantsId}/records`: 특정 참가자의 기록 확인
  - POST `/participants/{participantsId}/records`: 특정 참가자에 기록 추가
  - PATCH `/records/{recordId}/note`: 특정 기록의 비고란 입력
  - PATCH `/records/{recordId}/status`: 특정 기록의 상태 변경(초기에는 pending, 나중에 approved, rejected로 변경 가능)
  - GET `/records/divisions/{divisionId}/top`: 특정 대회 부문에 대해 모든 참가자들의 최고 기록 조회