### PR TITLE
Timer 서비스 구현 및 컨트롤러 등록

### DIFF
--- a/server/src/container.ts
+++ b/server/src/container.ts
@@ -4,6 +4,7 @@ import {
   CompetitionService,
   ParticipantService,
   RecordService,
+  TimerLogService,
 } from "@/core/services";
 
 import { ActorIdPwSQLiteRepository } from "@/repositories/actor-id-pw-sqlite";
@@ -12,12 +13,14 @@ import { CompetitionSQLiteRepository } from "@/repositories/competition-sqlite";
 import { DivisionSQLiteRepository } from "@/repositories/division-sqlite";
 import { ParticipantSQLiteRepository } from "@/repositories/participant-sqlite";
 import { RecordSQLiteRepository } from "@/repositories/record-sqlite";
+import { TimerLogSQLiteRepository } from "@/repositories/timer-log-sqlite";
 
 import { ActorServiceImpl } from "@/services/actor";
 import { ActorSessionRandomService } from "@/services/actor-session-random";
 import { CompetitionServiceImpl } from "@/services/competition";
 import { ParticipantServiceImpl } from "@/services/participant";
 import { RecordServiceImpl } from "@/services/record";
+import { TimerLogServiceImpl } from "@/services/timer-log";
 
 import sqlite3 from "sqlite3";
 
@@ -53,6 +56,7 @@ export class Container {
   private readonly divisionSQLiteRepo: DivisionSQLiteRepository;
   private readonly participantSQLiteRepo: ParticipantSQLiteRepository;
   private readonly recordSQLiteRepo: RecordSQLiteRepository;
+  private readonly timerLogSQLiteRepo: TimerLogSQLiteRepository;
 
   // Services
   private readonly actorService: ActorService;
@@ -60,6 +64,7 @@ export class Container {
   private readonly competitionService: CompetitionService;
   private readonly participantService: ParticipantService;
   private readonly recordService: RecordService;
+  private readonly timerLogService: TimerLogService;
 
   private constructor() {
     // SQLite Database
@@ -80,6 +85,7 @@ export class Container {
     this.divisionSQLiteRepo = new DivisionSQLiteRepository(this.db);
     this.participantSQLiteRepo = new ParticipantSQLiteRepository(this.db);
     this.recordSQLiteRepo = new RecordSQLiteRepository(this.db);
+    this.timerLogSQLiteRepo = new TimerLogSQLiteRepository(this.db);
 
     this.actorService = new ActorServiceImpl({
       actorRepository: this.actorSQLiteRepo,
@@ -99,6 +105,9 @@ export class Container {
     this.recordService = new RecordServiceImpl({
       recordRepository: this.recordSQLiteRepo,
       participantRepository: this.participantSQLiteRepo,
+    });
+    this.timerLogService = new TimerLogServiceImpl({
+      timerLogRepository: this.timerLogSQLiteRepo,
     });
   }
 
@@ -127,6 +136,7 @@ export class Container {
       this.actorIdPwSQLiteRepo.initialize(),
       this.participantSQLiteRepo.initialize(),
       this.recordSQLiteRepo.initialize(),
+      this.timerLogSQLiteRepo.initialize(),
     ]);
 
     this.initialized = true;
@@ -139,6 +149,7 @@ export class Container {
       competition: this.competitionService,
       participant: this.participantService,
       record: this.recordService,
+      timerLog: this.timerLogService,
     };
   }
 }

--- a/server/src/core/errors.ts
+++ b/server/src/core/errors.ts
@@ -32,3 +32,10 @@ export class UsernameAlreadyExistsError extends Error {
     this.name = "UsernameAlreadyExistsError";
   }
 }
+
+export class TimerLogConsecutiveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimerLogConsecutiveError";
+  }
+}

--- a/server/src/core/models.ts
+++ b/server/src/core/models.ts
@@ -65,10 +65,9 @@ export interface TimerLog {
    * 타이머 로그 타입
    * - "start": 타이머 시작, value는 시작 시각(unix timestamp)
    * - "stop": 타이머 정지, value는 정지 시각(unix timestamp)
-   * - "add": 타이머에 추가 시간, value는 추가된 시간(ms)
-   * - "sub": 타이머에서 시간 차감, value는 차감된 시간(ms)
+   * - "adjust": 타이머 시간 조정, value는 조정된 시간(ms, 양수는 추가, 음수는 차감)
    */
-  type: "start" | "stop" | "add" | "sub";
+  type: "start" | "stop" | "adjust";
   createdAt: Date;
 }
 

--- a/server/src/core/services.ts
+++ b/server/src/core/services.ts
@@ -177,27 +177,36 @@ export interface TimerLogService {
   /**
    * 특정 참가자의 경연 타이머를 시작할 수 있다. 현재 시각을 기준으로 타이머가 시작된다.
    */
-  startTimer(actorId: string, participantId: string): Promise<TimerLog>;
+  startTimer(actor: Actor, participantId: string): Promise<TimerLog>;
 
   /**
    * 특정 참가자의 경연 타이머를 중지할 수 있다. 현재 시각을 기준으로 타이머가 중지된다.
    */
-  stopTimer(actorId: string, participantId: string): Promise<void>;
+  stopTimer(actor: Actor, participantId: string): Promise<TimerLog>;
+
+  /**
+   * 특정 참가자의 타이머 시간을 조정할 수 있다. 양수는 시간 추가, 음수는 시간 차감을 의미한다.
+   */
+  adjustTimer(
+    actor: Actor,
+    participantId: string,
+    adjustmentMs: number
+  ): Promise<TimerLog>;
 
   /**
    * 특정 참가자의 타이머 기록을 조회할 수 있다.
    */
-  getTimerLogs(actorId: string, participantId: string): Promise<TimerLog[]>;
+  getTimerLogs(actor: Actor, participantId: string): Promise<TimerLog[]>;
 
   // -----------------------------
   // Observable 구독 관련 메서드들
   // -----------------------------
   /**
-   * 특정 참가자의 남은 경연 시간 타이머 변경 이벤트를 구독할 수 있다.
+   * 특정 참가자에 대한 타이머 기록 추가 이벤트를 구독할 수 있다.
    */
   subscribeTimerLogsChanged(
     participantId: string,
-    callback: (timerLogs: TimerLog[]) => void
+    callback: (timerLog: TimerLog) => Promise<void>
   ): Unsubscriber;
 }
 

--- a/server/src/http/app.module.ts
+++ b/server/src/http/app.module.ts
@@ -7,6 +7,7 @@ import {
   CompetitionService,
   ParticipantService,
   RecordService,
+  TimerLogService,
 } from "@/core/services";
 
 import { ActorController } from "./controllers/actor.controller";
@@ -42,6 +43,10 @@ const recordService: CustomProvider<RecordService> = {
   provide: "RecordService",
   useValue: di.services.record,
 };
+const timerLogService: CustomProvider<TimerLogService> = {
+  provide: "TimerLogService",
+  useValue: di.services.timerLog,
+};
 
 @Module({
   controllers: [
@@ -57,6 +62,7 @@ const recordService: CustomProvider<RecordService> = {
     competitionService,
     participantService,
     recordService,
+    timerLogService,
   ],
 })
 export class AppModule {

--- a/server/src/http/controllers/participant.controller.ts
+++ b/server/src/http/controllers/participant.controller.ts
@@ -1,5 +1,9 @@
-import { Actor } from "@/core/models";
-import { ParticipantService, RecordService } from "@/core/services";
+import { Actor, TimerLog } from "@/core/models";
+import {
+  ParticipantService,
+  RecordService,
+  TimerLogService,
+} from "@/core/services";
 
 import {
   Body,
@@ -23,6 +27,7 @@ import {
   UpdateParticipantDto,
 } from "../dtos/participant.dto";
 import { AddRecordDto, RecordResponseDto } from "../dtos/record.dto";
+import { AdjustTimerDto, TimerLogResponseDto } from "../dtos/timer-log.dto";
 
 @ApiTags("Participants")
 @Controller("participants")
@@ -31,7 +36,9 @@ export class ParticipantController {
     @Inject("ParticipantService")
     private readonly participantService: ParticipantService,
     @Inject("RecordService")
-    private readonly recordService: RecordService
+    private readonly recordService: RecordService,
+    @Inject("TimerLogService")
+    private readonly timerLogService: TimerLogService
   ) {}
 
   @Patch("/:participantId")
@@ -99,5 +106,68 @@ export class ParticipantController {
       body.source,
       body.note
     );
+  }
+
+  @Post("/:participantId/timer/start")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "타이머 시작 성공 및 생성된 타이머 로그 반환",
+    type: TimerLogResponseDto,
+  })
+  async startTimer(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string
+  ): Promise<TimerLog> {
+    return this.timerLogService.startTimer(actor, participantId);
+  }
+
+  @Post("/:participantId/timer/stop")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "타이머 중지 성공 및 생성된 타이머 로그 반환",
+    type: TimerLogResponseDto,
+  })
+  async stopTimer(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string
+  ): Promise<TimerLog> {
+    return this.timerLogService.stopTimer(actor, participantId);
+  }
+
+  @Post("/:participantId/timer/adjust")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "타이머 조정 성공 및 생성된 타이머 로그 반환",
+    type: TimerLogResponseDto,
+  })
+  async adjustTimer(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string,
+    @Body() body: AdjustTimerDto
+  ): Promise<TimerLog> {
+    return this.timerLogService.adjustTimer(
+      actor,
+      participantId,
+      body.adjustmentMs
+    );
+  }
+
+  @Get("/:participantId/timer/logs")
+  @ApiResponse({
+    status: 200,
+    description: "특정 참가자의 모든 타이머 로그 목록 반환",
+    type: [TimerLogResponseDto],
+  })
+  async getTimerLogs(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string
+  ): Promise<TimerLog[]> {
+    return this.timerLogService.getTimerLogs(actor, participantId);
   }
 }

--- a/server/src/http/dtos/timer-log.dto.ts
+++ b/server/src/http/dtos/timer-log.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNumber } from "class-validator";
+
+export class TimerLogResponseDto {
+  @ApiProperty({ type: String, description: "타이머 로그 ID" })
+  id!: string;
+
+  @ApiProperty({ type: String, description: "참가자 ID" })
+  participantId!: string;
+
+  @ApiProperty({
+    type: Number,
+    description: "타이머 값",
+    example: 953996400000,
+  })
+  value!: number;
+
+  @ApiProperty({
+    type: String,
+    description: "타이머 로그 타입",
+    enum: ["start", "stop", "adjust"],
+    example: "start",
+  })
+  type!: "start" | "stop" | "adjust";
+
+  @ApiProperty({ type: String, description: "생성 시각", format: "date-time" })
+  createdAt!: Date;
+}
+
+export class AdjustTimerDto {
+  @ApiProperty({
+    description: "타이머 조정 시간 (밀리초, 양수는 추가, 음수는 차감)",
+    example: 5000,
+  })
+  @IsNumber()
+  adjustmentMs!: number;
+}

--- a/server/src/http/exception.filter.ts
+++ b/server/src/http/exception.filter.ts
@@ -1,8 +1,9 @@
 import {
-  PersistenceError,
-  EntityNotFoundError,
-  AuthorizationError,
   AuthenticationError,
+  AuthorizationError,
+  EntityNotFoundError,
+  PersistenceError,
+  TimerLogConsecutiveError,
   UsernameAlreadyExistsError,
 } from "@/core/errors";
 import {
@@ -72,6 +73,13 @@ export class CustomExceptionFilter implements ExceptionFilter {
         error = {
           statusCode: HttpStatus.CONFLICT,
           type: "UsernameAlreadyExistsError",
+          message: exception.message,
+        };
+        break;
+      case exception instanceof TimerLogConsecutiveError:
+        error = {
+          statusCode: HttpStatus.BAD_REQUEST,
+          type: "TimerLogConsecutiveError",
           message: exception.message,
         };
         break;

--- a/server/src/services/timer-log.ts
+++ b/server/src/services/timer-log.ts
@@ -1,0 +1,142 @@
+import { Actor, TimerLog } from "@/core/models";
+import { TimerLogRepository } from "@/core/repositories";
+import { TimerLogService, Unsubscriber } from "@/core/services";
+
+import { EventEmitter } from "events";
+import { v4 as uuidv4 } from "uuid";
+
+import { requireAnyRole } from "@/utils/auth";
+import { TimerLogConsecutiveError } from "@/core/errors";
+
+export class TimerLogServiceImpl implements TimerLogService {
+  private readonly timerLogRepo: TimerLogRepository;
+
+  constructor(di: { timerLogRepository: TimerLogRepository }) {
+    this.timerLogRepo = di.timerLogRepository;
+  }
+
+  async checkTimerIsRunning(participantId: string): Promise<boolean> {
+    let lastStartLog: TimerLog | null = null;
+    let lastStopLog: TimerLog | null = null;
+
+    const timerLogs = await this.timerLogRepo.getByParticipantId(participantId);
+    for (let i = timerLogs.length - 1; i >= 0; i--) {
+      const logType = timerLogs[i].type;
+      if (logType === "start" && lastStartLog === null) {
+        lastStartLog = timerLogs[i];
+      } else if (logType === "stop" && lastStopLog === null) {
+        lastStopLog = timerLogs[i];
+      }
+    }
+
+    if (lastStartLog === null) {
+      return false; // 타이머가 한 번도 시작되지 않은 경우
+    }
+    if (lastStopLog === null) {
+      return true; // 타이머가 시작되었지만 중지되지 않은 경우
+    }
+    return lastStartLog.createdAt > lastStopLog.createdAt;
+  }
+
+  async startTimer(actor: Actor, participantId: string): Promise<TimerLog> {
+    requireAnyRole(actor, "administrator");
+    const isRunning = await this.checkTimerIsRunning(participantId);
+    if (isRunning === true) {
+      throw new TimerLogConsecutiveError("Timer is already running");
+    }
+
+    const now = Date.now();
+    const timerLog: TimerLog = {
+      id: uuidv4(),
+      participantId,
+      value: now,
+      type: "start",
+      createdAt: new Date(now),
+    };
+
+    const result = await this.timerLogRepo.create(timerLog);
+    this.emitTimerLogsChanged(result);
+    return result;
+  }
+
+  async stopTimer(actor: Actor, participantId: string): Promise<TimerLog> {
+    requireAnyRole(actor, "administrator");
+    const isRunning = await this.checkTimerIsRunning(participantId);
+    if (isRunning === false) {
+      throw new TimerLogConsecutiveError("Timer is not running");
+    }
+
+    const now = Date.now();
+    const timerLog: TimerLog = {
+      id: uuidv4(),
+      participantId,
+      value: now,
+      type: "stop",
+      createdAt: new Date(now),
+    };
+
+    const result = await this.timerLogRepo.create(timerLog);
+    this.emitTimerLogsChanged(result);
+    return result;
+  }
+
+  async adjustTimer(
+    actor: Actor,
+    participantId: string,
+    adjustmentMs: number
+  ): Promise<TimerLog> {
+    requireAnyRole(actor, "administrator");
+
+    const timerLog: TimerLog = {
+      id: uuidv4(),
+      participantId,
+      value: adjustmentMs,
+      type: "adjust",
+      createdAt: new Date(),
+    };
+
+    const result = await this.timerLogRepo.create(timerLog);
+    this.emitTimerLogsChanged(result);
+    return result;
+  }
+
+  async getTimerLogs(actor: Actor, participantId: string): Promise<TimerLog[]> {
+    return this.timerLogRepo.getByParticipantId(participantId);
+  }
+
+  // ------------------------------
+  // 이벤트 핸들링 관련 로직
+  // ------------------------------
+  private eventEmitter = new EventEmitter();
+
+  private getTimerLogsChangedEventName = (participantId: string) =>
+    `timerLogs:changed:${participantId}`;
+
+  private emitTimerLogsChanged(timerLog: TimerLog) {
+    this.eventEmitter.emit(
+      this.getTimerLogsChangedEventName(timerLog.participantId),
+      timerLog
+    );
+  }
+
+  subscribeTimerLogsChanged(
+    participantId: string,
+    callback: (timerLog: TimerLog) => Promise<void>
+  ): Unsubscriber {
+    const eventName = this.getTimerLogsChangedEventName(participantId);
+    const safeCb = async (timerLog: TimerLog) => {
+      try {
+        await callback(timerLog);
+      } catch (err) {
+        console.error(
+          `TimerLogsChanged listener error for ${participantId}:`,
+          err
+        );
+      }
+    };
+    this.eventEmitter.on(eventName, safeCb);
+    return () => {
+      this.eventEmitter.off(eventName, safeCb);
+    };
+  }
+}

--- a/server/tests/shared/repositories/timer-log.contract.ts
+++ b/server/tests/shared/repositories/timer-log.contract.ts
@@ -22,17 +22,15 @@ export function runTimerLogRepositoryContract(
       }
     });
 
-    const logTypes: TimerLog["type"][] = ["start", "stop", "add", "sub"];
+    const logTypes: TimerLog["type"][] = ["start", "stop", "adjust"];
 
     function createEntity(order: number, participantId?: string): TimerLog {
       const logType = logTypes[order % logTypes.length];
       let value = Date.now();
       if (logType === "stop") {
         value = Date.now() + 10000; // 10초 뒤
-      } else if (logType === "add") {
-        value = 3000; // 3초 추가
-      } else if (logType === "sub") {
-        value = 1000; // 1초 삭감
+      } else if (logType === "adjust") {
+        value = order % 2 === 0 ? 3000 : -1000; // 3초 추가 또는 1초 차감
       }
 
       return {
@@ -73,7 +71,7 @@ export function runTimerLogRepositoryContract(
       const updated: TimerLog = {
         ...original,
         value: 2000,
-        type: "add",
+        type: "adjust",
       };
       await repo.update(updated);
       const loaded = await repo.getById(original.id);

--- a/server/tests/unit/services/timer-log.test.ts
+++ b/server/tests/unit/services/timer-log.test.ts
@@ -1,0 +1,310 @@
+import { AuthorizationError, TimerLogConsecutiveError } from "@/core/errors";
+import { Actor, TimerLog } from "@/core/models";
+import { TimerLogRepository } from "@/core/repositories";
+
+import { TimerLogServiceImpl } from "@/services/timer-log";
+
+import { v4 as uuidv4 } from "uuid";
+
+const mockTimerLogRepo: jest.Mocked<TimerLogRepository> = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getByParticipantId: jest.fn(),
+};
+
+const generateDummyTimerLog = (
+  participantId: string,
+  type: TimerLog["type"],
+  value: number
+): TimerLog => ({
+  id: uuidv4(),
+  participantId,
+  value,
+  type,
+  createdAt: new Date(),
+});
+
+describe("TimerLogService 구현체 단위 테스트", () => {
+  let service: TimerLogServiceImpl;
+  let adminActor: Actor;
+  let anonymousActor: Actor;
+
+  beforeAll(() => {
+    // Arrange: 테스트에 필요한 액터들을 준비
+    adminActor = {
+      id: uuidv4(),
+      name: "관리자",
+      roles: ["administrator"],
+      createdAt: new Date(),
+    };
+    anonymousActor = {
+      id: uuidv4(),
+      name: "익명 사용자",
+      roles: [],
+      createdAt: new Date(),
+    };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TimerLogServiceImpl({
+      timerLogRepository: mockTimerLogRepo,
+    });
+  });
+
+  it("아무나 특정 참가자의 타이머 기록을 조회할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const timerLogs: TimerLog[] = [
+      generateDummyTimerLog(participantId, "start", Date.now()),
+      generateDummyTimerLog(participantId, "stop", Date.now()),
+    ];
+    mockTimerLogRepo.getByParticipantId.mockResolvedValue(timerLogs);
+
+    // Act
+    const result = await service.getTimerLogs(anonymousActor, participantId);
+
+    // Assert
+    expect(result).toEqual(timerLogs);
+    expect(mockTimerLogRepo.getByParticipantId).toHaveBeenCalledWith(
+      participantId
+    );
+  });
+
+  it("관리자만 타이머를 시작할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const timerLog = generateDummyTimerLog(participantId, "start", Date.now());
+    mockTimerLogRepo.create.mockResolvedValue(timerLog);
+    jest.spyOn(service, "checkTimerIsRunning").mockResolvedValue(false);
+
+    // Act & Assert: 권한이 없는 사용자는 타이머 시작 불가
+    await expect(
+      service.startTimer(anonymousActor, participantId)
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert: 관리자는 타이머 시작 가능
+    const adminResult = await service.startTimer(adminActor, participantId);
+    expect(adminResult).toEqual(timerLog);
+    expect(mockTimerLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participantId,
+        type: "start",
+      })
+    );
+  });
+
+  it("관리자만 타이머를 중지할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const timerLog = generateDummyTimerLog(participantId, "stop", Date.now());
+    mockTimerLogRepo.create.mockResolvedValue(timerLog);
+    jest.spyOn(service, "checkTimerIsRunning").mockResolvedValue(true);
+
+    // Act & Assert: 권한이 없는 사용자는 타이머 중지 불가
+    await expect(
+      service.stopTimer(anonymousActor, participantId)
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert: 관리자는 타이머 중지 가능
+    const adminResult = await service.stopTimer(adminActor, participantId);
+    expect(adminResult).toEqual(timerLog);
+    expect(mockTimerLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participantId,
+        type: "stop",
+      })
+    );
+  });
+
+  it("관리자만 타이머를 조정할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const adjustmentMs = 5000;
+    const timerLog = generateDummyTimerLog(
+      participantId,
+      "adjust",
+      adjustmentMs
+    );
+    mockTimerLogRepo.create.mockResolvedValue(timerLog);
+
+    // Act & Assert: 권한이 없는 사용자는 타이머 조정 불가
+    await expect(
+      service.adjustTimer(anonymousActor, participantId, adjustmentMs)
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert: 관리자는 타이머 조정 가능
+    const adminResult = await service.adjustTimer(
+      adminActor,
+      participantId,
+      adjustmentMs
+    );
+    expect(adminResult).toEqual(timerLog);
+    expect(mockTimerLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participantId,
+        type: "adjust",
+        value: adjustmentMs,
+      })
+    );
+  });
+
+  it("타이머가 시작된 상태에서는 타이머를 시작할 수 없다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const timerLogs: TimerLog[] = [
+      generateDummyTimerLog(participantId, "adjust", 1000),
+      generateDummyTimerLog(participantId, "start", Date.now()),
+    ];
+    mockTimerLogRepo.getByParticipantId.mockResolvedValue(timerLogs);
+
+    // Act
+    const asyncTask = service.startTimer(adminActor, participantId);
+
+    // Assert
+    await expect(asyncTask).rejects.toThrow(TimerLogConsecutiveError);
+  });
+
+  it("타이머가 중지된 상태에서는 타이머를 중지할 수 없다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const timerLogs: TimerLog[] = [
+      generateDummyTimerLog(participantId, "adjust", 1000),
+      generateDummyTimerLog(participantId, "start", Date.now()),
+      generateDummyTimerLog(participantId, "stop", Date.now()),
+    ];
+    mockTimerLogRepo.getByParticipantId.mockResolvedValue(timerLogs);
+
+    // Act
+    const asyncTask = service.stopTimer(adminActor, participantId);
+
+    // Assert
+    await expect(asyncTask).rejects.toThrow(TimerLogConsecutiveError);
+  });
+
+  describe("타이머 로그 이벤트 구독 테스트", () => {
+    let participantId: string;
+    let callback1: jest.Mock;
+    let callback2: jest.Mock;
+    let callback1Unsubscriber: () => void;
+    let callback2Unsubscriber: () => void;
+
+    beforeEach(() => {
+      // Arrange
+      participantId = uuidv4();
+      callback1 = jest.fn();
+      callback2 = jest.fn();
+      callback1Unsubscriber = service.subscribeTimerLogsChanged(
+        participantId,
+        callback1
+      );
+      callback2Unsubscriber = service.subscribeTimerLogsChanged(
+        participantId,
+        callback2
+      );
+    });
+
+    afterEach(() => {
+      callback1Unsubscriber();
+      callback2Unsubscriber();
+      jest.clearAllMocks();
+    });
+
+    it("타이머가 시작되었을 때 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const timerLog = generateDummyTimerLog(
+        participantId,
+        "start",
+        Date.now()
+      );
+      mockTimerLogRepo.create.mockResolvedValue(timerLog);
+      jest.spyOn(service, "checkTimerIsRunning").mockResolvedValue(false);
+
+      // Act
+      await service.startTimer(adminActor, participantId);
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(timerLog);
+      expect(callback2).toHaveBeenCalledWith(timerLog);
+    });
+
+    it("타이머가 중지되었을 때 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const timerLog = generateDummyTimerLog(participantId, "stop", Date.now());
+      mockTimerLogRepo.create.mockResolvedValue(timerLog);
+      jest.spyOn(service, "checkTimerIsRunning").mockResolvedValue(true);
+
+      // Act
+      await service.stopTimer(adminActor, participantId);
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(timerLog);
+      expect(callback2).toHaveBeenCalledWith(timerLog);
+    });
+
+    it("타이머가 조정되었을 때 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const adjustmentMs = -3000;
+      const timerLog = generateDummyTimerLog(
+        participantId,
+        "adjust",
+        adjustmentMs
+      );
+      mockTimerLogRepo.create.mockResolvedValue(timerLog);
+
+      // Act
+      await service.adjustTimer(adminActor, participantId, adjustmentMs);
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(timerLog);
+      expect(callback2).toHaveBeenCalledWith(timerLog);
+    });
+
+    it("구독 함수에서 오류가 발생해도 서비스 로직은 정상적으로 동작한다.", async () => {
+      // Arrange
+      const timerLog = generateDummyTimerLog(
+        participantId,
+        "start",
+        Date.now()
+      );
+      mockTimerLogRepo.create.mockResolvedValue(timerLog);
+      callback1.mockRejectedValue(
+        new Error("에러가 발생해도 서비스 로직은 정상적으로 동작해야 해요.")
+      );
+      const errorSpy = jest // 오류 메시지 출력 방지
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      // Act
+      const asyncTask = service.startTimer(adminActor, participantId);
+
+      // Assert
+      await expect(asyncTask).resolves.toBe(timerLog);
+      expect(callback1).toHaveBeenCalledWith(timerLog);
+      expect(callback2).toHaveBeenCalledWith(timerLog);
+
+      // Cleanup
+      errorSpy.mockRestore();
+    });
+
+    it("구독을 해제하면 더 이상 이벤트를 받지 않는다.", async () => {
+      // Arrange
+      const timerLog = generateDummyTimerLog(
+        participantId,
+        "start",
+        Date.now()
+      );
+      mockTimerLogRepo.create.mockResolvedValue(timerLog);
+      callback1Unsubscriber();
+
+      // Act
+      await service.startTimer(adminActor, participantId);
+
+      // Assert
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledWith(timerLog);
+    });
+  });
+});


### PR DESCRIPTION
Closes #34

## 변경 사항
- TimerLog.type에서 add, sub를 adjust 타입으로 통합
- TimerLogService에서 adjustTimer 메서드 추가
- 아래의 API 추가
  - POST `/participants/{participantId}/timer/start`: 특정 참가자 타이머 시작
  - POST `/participants/{participantId}/timer/stop`: 특정 참가자 타이머 중지
  - POST `/participants/{participantId}/timer/adjust`: 특정 참가자 타이머 시간 추가/삭감(delta값)
  - GET `/participants/{participantId}/timer/logs`: 특정  참가자 타이머 로그 조회