### PR TITLE
ManualRecord 서비스 추가 및 API 등록

### DIFF
--- a/server/src/container.ts
+++ b/server/src/container.ts
@@ -2,6 +2,7 @@ import {
   ActorService,
   ActorSessionService,
   CompetitionService,
+  ManualRecordService,
   ParticipantService,
   RecordService,
   TimerLogService,
@@ -11,6 +12,7 @@ import { ActorIdPwSQLiteRepository } from "@/repositories/actor-id-pw-sqlite";
 import { ActorSQLiteRepository } from "@/repositories/actor-sqlite";
 import { CompetitionSQLiteRepository } from "@/repositories/competition-sqlite";
 import { DivisionSQLiteRepository } from "@/repositories/division-sqlite";
+import { ManualRecordSQLiteRepository } from "@/repositories/manual-record-sqlite";
 import { ParticipantSQLiteRepository } from "@/repositories/participant-sqlite";
 import { RecordSQLiteRepository } from "@/repositories/record-sqlite";
 import { TimerLogSQLiteRepository } from "@/repositories/timer-log-sqlite";
@@ -18,6 +20,7 @@ import { TimerLogSQLiteRepository } from "@/repositories/timer-log-sqlite";
 import { ActorServiceImpl } from "@/services/actor";
 import { ActorSessionRandomService } from "@/services/actor-session-random";
 import { CompetitionServiceImpl } from "@/services/competition";
+import { ManualRecordServiceImpl } from "@/services/manual-record";
 import { ParticipantServiceImpl } from "@/services/participant";
 import { RecordServiceImpl } from "@/services/record";
 import { TimerLogServiceImpl } from "@/services/timer-log";
@@ -54,6 +57,7 @@ export class Container {
   private readonly actorSQLiteRepo: ActorSQLiteRepository;
   private readonly competitionSQLiteRepo: CompetitionSQLiteRepository;
   private readonly divisionSQLiteRepo: DivisionSQLiteRepository;
+  private readonly manualRecordSQLiteRepo: ManualRecordSQLiteRepository;
   private readonly participantSQLiteRepo: ParticipantSQLiteRepository;
   private readonly recordSQLiteRepo: RecordSQLiteRepository;
   private readonly timerLogSQLiteRepo: TimerLogSQLiteRepository;
@@ -62,6 +66,7 @@ export class Container {
   private readonly actorService: ActorService;
   private readonly actorSessionService: ActorSessionService;
   private readonly competitionService: CompetitionService;
+  private readonly manualRecordService: ManualRecordService;
   private readonly participantService: ParticipantService;
   private readonly recordService: RecordService;
   private readonly timerLogService: TimerLogService;
@@ -83,6 +88,7 @@ export class Container {
     this.actorSQLiteRepo = new ActorSQLiteRepository(this.db);
     this.competitionSQLiteRepo = new CompetitionSQLiteRepository(this.db);
     this.divisionSQLiteRepo = new DivisionSQLiteRepository(this.db);
+    this.manualRecordSQLiteRepo = new ManualRecordSQLiteRepository(this.db);
     this.participantSQLiteRepo = new ParticipantSQLiteRepository(this.db);
     this.recordSQLiteRepo = new RecordSQLiteRepository(this.db);
     this.timerLogSQLiteRepo = new TimerLogSQLiteRepository(this.db);
@@ -105,6 +111,9 @@ export class Container {
     this.recordService = new RecordServiceImpl({
       recordRepository: this.recordSQLiteRepo,
       participantRepository: this.participantSQLiteRepo,
+    });
+    this.manualRecordService = new ManualRecordServiceImpl({
+      manualRecordRepository: this.manualRecordSQLiteRepo,
     });
     this.timerLogService = new TimerLogServiceImpl({
       timerLogRepository: this.timerLogSQLiteRepo,
@@ -134,6 +143,7 @@ export class Container {
       this.divisionSQLiteRepo.initialize(),
       this.actorSQLiteRepo.initialize(),
       this.actorIdPwSQLiteRepo.initialize(),
+      this.manualRecordSQLiteRepo.initialize(),
       this.participantSQLiteRepo.initialize(),
       this.recordSQLiteRepo.initialize(),
       this.timerLogSQLiteRepo.initialize(),
@@ -147,6 +157,7 @@ export class Container {
       actor: this.actorService,
       actorSession: this.actorSessionService,
       competition: this.competitionService,
+      manualRecord: this.manualRecordService,
       participant: this.participantService,
       record: this.recordService,
       timerLog: this.timerLogService,

--- a/server/src/core/models.ts
+++ b/server/src/core/models.ts
@@ -54,7 +54,6 @@ export interface ManualRecord {
   value: number; // 기록 값
   recorderName: string; // 수동 계수자 이름
   createdAt: Date; // 생성일
-  invalidatedAt: Date | null; // 무효화된(사용 또는 무시를 의미함) 시각
 }
 
 export interface TimerLog {

--- a/server/src/core/services.ts
+++ b/server/src/core/services.ts
@@ -267,7 +267,7 @@ export interface ManualRecordService {
    * 특정 참가자에 대한 수동 계수 기록을 조회할 수 있다.
    */
   getManualRecords(
-    actorId: string,
+    actor: Actor,
     participantId: string
   ): Promise<ManualRecord[]>;
 
@@ -275,18 +275,10 @@ export interface ManualRecordService {
    * 특정 참가자에 대한 수동 계수 기록을 추가할 수 있다.
    */
   addManualRecord(
-    actorId: string,
+    actor: Actor,
     participantId: string,
     value: number,
     recorderName: string
-  ): Promise<ManualRecord>;
-
-  /**
-   * 특정 수동 계수 기록을 무효화할 수 있다.
-   */
-  invalidateManualRecord(
-    actorId: string,
-    manualRecordId: string
   ): Promise<ManualRecord>;
 
   // -----------------------------
@@ -297,7 +289,7 @@ export interface ManualRecordService {
    */
   subscribeManualRecordAdded(
     participantId: string,
-    callback: (manualRecord: ManualRecord) => void
+    callback: (manualRecord: ManualRecord) => Promise<void>
   ): Unsubscriber;
 }
 

--- a/server/src/http/app.module.ts
+++ b/server/src/http/app.module.ts
@@ -5,6 +5,7 @@ import {
   ActorService,
   ActorSessionService,
   CompetitionService,
+  ManualRecordService,
   ParticipantService,
   RecordService,
   TimerLogService,
@@ -47,6 +48,10 @@ const timerLogService: CustomProvider<TimerLogService> = {
   provide: "TimerLogService",
   useValue: di.services.timerLog,
 };
+const manualRecordService: CustomProvider<ManualRecordService> = {
+  provide: "ManualRecordService",
+  useValue: di.services.manualRecord,
+};
 
 @Module({
   controllers: [
@@ -60,6 +65,7 @@ const timerLogService: CustomProvider<TimerLogService> = {
     actorService,
     actorSessionService,
     competitionService,
+    manualRecordService,
     participantService,
     recordService,
     timerLogService,

--- a/server/src/http/controllers/participant.controller.ts
+++ b/server/src/http/controllers/participant.controller.ts
@@ -1,5 +1,6 @@
-import { Actor, TimerLog } from "@/core/models";
+import { Actor, ManualRecord, TimerLog } from "@/core/models";
 import {
+  ManualRecordService,
   ParticipantService,
   RecordService,
   TimerLogService,
@@ -28,6 +29,10 @@ import {
 } from "../dtos/participant.dto";
 import { AddRecordDto, RecordResponseDto } from "../dtos/record.dto";
 import { AdjustTimerDto, TimerLogResponseDto } from "../dtos/timer-log.dto";
+import {
+  AddManualRecordDto,
+  ManualRecordResponseDto,
+} from "../dtos/manual-record.dto";
 
 @ApiTags("Participants")
 @Controller("participants")
@@ -38,7 +43,9 @@ export class ParticipantController {
     @Inject("RecordService")
     private readonly recordService: RecordService,
     @Inject("TimerLogService")
-    private readonly timerLogService: TimerLogService
+    private readonly timerLogService: TimerLogService,
+    @Inject("ManualRecordService")
+    private readonly manualRecordService: ManualRecordService
   ) {}
 
   @Patch("/:participantId")
@@ -105,6 +112,40 @@ export class ParticipantController {
       body.value,
       body.source,
       body.note
+    );
+  }
+
+  @Get("/:participantId/manual-records")
+  @ApiResponse({
+    status: 200,
+    description: "특정 참가자의 모든 수동 계수 기록 목록 반환",
+    type: [ManualRecordResponseDto],
+  })
+  async getManualRecords(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string
+  ): Promise<ManualRecord[]> {
+    return this.manualRecordService.getManualRecords(actor, participantId);
+  }
+
+  @Post("/:participantId/manual-records")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "수동 계수 기록 추가 성공 및 추가된 기록 정보 반환",
+    type: ManualRecordResponseDto,
+  })
+  async addManualRecord(
+    @CurrentActor() actor: Actor,
+    @Param("participantId") participantId: string,
+    @Body() body: AddManualRecordDto
+  ): Promise<ManualRecord> {
+    return this.manualRecordService.addManualRecord(
+      actor,
+      participantId,
+      body.value,
+      body.recorderName
     );
   }
 

--- a/server/src/http/dtos/manual-record.dto.ts
+++ b/server/src/http/dtos/manual-record.dto.ts
@@ -1,0 +1,59 @@
+import { ManualRecord } from "@/core/models";
+
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+
+export class ManualRecordResponseDto implements ManualRecord {
+  @ApiProperty({
+    type: String,
+    description: "수동 계수 기록 ID",
+  })
+  id!: string;
+
+  @ApiProperty({
+    type: String,
+    description: "참가자 ID",
+  })
+  participantId!: string;
+
+  @ApiProperty({
+    type: Number,
+    description: "수동 계수 기록 값 (밀리초)",
+    example: 5000,
+  })
+  value!: number;
+
+  @ApiProperty({
+    type: String,
+    description: "수동 계수자 이름",
+    example: "김계란",
+  })
+  recorderName!: string;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    description: "생성 시각",
+  })
+  createdAt!: Date;
+}
+
+export class AddManualRecordDto {
+  @ApiProperty({
+    type: Number,
+    description: "수동 계수 기록 값 (밀리초)",
+    example: 5000,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  value!: number;
+
+  @ApiProperty({
+    type: String,
+    description: "수동 계수자 이름",
+    example: "김계란",
+  })
+  @IsString()
+  @IsNotEmpty()
+  recorderName!: string;
+}

--- a/server/src/repositories/manual-record-sqlite.ts
+++ b/server/src/repositories/manual-record-sqlite.ts
@@ -11,7 +11,6 @@ type ManualRecordRecord = {
   value: number;
   recorderName: string;
   createdAt: string;
-  invalidatedAt: string | null;
   isDeleted: number;
 };
 
@@ -31,7 +30,6 @@ export class ManualRecordSQLiteRepository implements ManualRecordRepository {
           value INTEGER NOT NULL,
           recorderName TEXT NOT NULL,
           createdAt TEXT NOT NULL,
-          invalidatedAt TEXT,
           isDeleted INTEGER NOT NULL
         )`
       );
@@ -55,9 +53,6 @@ export class ManualRecordSQLiteRepository implements ManualRecordRepository {
       value: record.value,
       recorderName: record.recorderName,
       createdAt: new Date(record.createdAt),
-      invalidatedAt: record.invalidatedAt
-        ? new Date(record.invalidatedAt)
-        : null,
     };
   }
 
@@ -81,15 +76,14 @@ export class ManualRecordSQLiteRepository implements ManualRecordRepository {
   async create(manualRecord: ManualRecord): Promise<ManualRecord> {
     await this.db
       .run(
-        `INSERT INTO manual_records (id, participantId, value, recorderName, createdAt, invalidatedAt, isDeleted)
-          VALUES (?, ?, ?, ?, ?, ?, 0)`,
+        `INSERT INTO manual_records (id, participantId, value, recorderName, createdAt, isDeleted)
+          VALUES (?, ?, ?, ?, ?, 0)`,
         [
           manualRecord.id,
           manualRecord.participantId,
           manualRecord.value,
           manualRecord.recorderName,
           manualRecord.createdAt.toISOString(),
-          manualRecord.invalidatedAt?.toISOString() || null,
         ]
       )
       .catch((err) => {
@@ -102,14 +96,13 @@ export class ManualRecordSQLiteRepository implements ManualRecordRepository {
     const result = await this.db
       .run(
         `UPDATE manual_records
-          SET participantId = ?, value = ?, recorderName = ?, createdAt = ?, invalidatedAt = ?
+          SET participantId = ?, value = ?, recorderName = ?, createdAt = ?
           WHERE id = ? AND isDeleted = 0`,
         [
           manualRecord.participantId,
           manualRecord.value,
           manualRecord.recorderName,
           manualRecord.createdAt.toISOString(),
-          manualRecord.invalidatedAt?.toISOString() || null,
           manualRecord.id,
         ]
       )

--- a/server/src/services/manual-record.ts
+++ b/server/src/services/manual-record.ts
@@ -1,0 +1,79 @@
+import { Actor, ManualRecord } from "@/core/models";
+import { ManualRecordRepository } from "@/core/repositories";
+import { ManualRecordService, Unsubscriber } from "@/core/services";
+
+import { EventEmitter } from "events";
+import { v4 as uuidv4 } from "uuid";
+
+import { requireAnyRole } from "@/utils/auth";
+
+export class ManualRecordServiceImpl implements ManualRecordService {
+  private readonly manualRecordRepo: ManualRecordRepository;
+
+  constructor(di: { manualRecordRepository: ManualRecordRepository }) {
+    this.manualRecordRepo = di.manualRecordRepository;
+  }
+
+  async getManualRecords(
+    actor: Actor,
+    participantId: string
+  ): Promise<ManualRecord[]> {
+    return this.manualRecordRepo.getByParticipantId(participantId);
+  }
+
+  async addManualRecord(
+    actor: Actor,
+    participantId: string,
+    value: number,
+    recorderName: string
+  ): Promise<ManualRecord> {
+    requireAnyRole(actor, "administrator", "manualRecorder");
+
+    const manualRecord: ManualRecord = {
+      id: uuidv4(),
+      participantId,
+      value,
+      recorderName,
+      createdAt: new Date(),
+    };
+    const result = await this.manualRecordRepo.create(manualRecord);
+    this.emitManualRecordAdded(result);
+    return result;
+  }
+
+  // ------------------------------
+  // 이벤트 핸들링 관련 로직
+  // ------------------------------
+  private eventEmitter = new EventEmitter();
+
+  private getManualRecordAddedEventName = (participantId: string) =>
+    `manual-record:added:${participantId}`;
+
+  private emitManualRecordAdded(manualRecord: ManualRecord) {
+    this.eventEmitter.emit(
+      this.getManualRecordAddedEventName(manualRecord.participantId),
+      manualRecord
+    );
+  }
+
+  subscribeManualRecordAdded(
+    participantId: string,
+    callback: (manualRecord: ManualRecord) => Promise<void>
+  ): Unsubscriber {
+    const eventName = this.getManualRecordAddedEventName(participantId);
+    const safeCb = async (manualRecord: ManualRecord) => {
+      try {
+        await callback(manualRecord);
+      } catch (err) {
+        console.error(
+          `Manual record added listener error for ${participantId}:`,
+          err
+        );
+      }
+    };
+    this.eventEmitter.on(eventName, safeCb);
+    return () => {
+      this.eventEmitter.off(eventName, safeCb);
+    };
+  }
+}

--- a/server/tests/shared/repositories/manual-record.contract.ts
+++ b/server/tests/shared/repositories/manual-record.contract.ts
@@ -29,7 +29,6 @@ export function runManualRecordRepositoryContract(
         value: Math.floor(Math.random() * 10000),
         recorderName: "테스트 계수자",
         createdAt: new Date(),
-        invalidatedAt: null,
       };
     }
 
@@ -63,7 +62,6 @@ export function runManualRecordRepositoryContract(
         ...original,
         value: 100000,
         recorderName: "수정된 계수자",
-        invalidatedAt: new Date(),
       };
       await repo.update(updated);
       const loaded = await repo.getById(original.id);

--- a/server/tests/unit/services/manual-record.test.ts
+++ b/server/tests/unit/services/manual-record.test.ts
@@ -1,0 +1,251 @@
+import { AuthorizationError } from "@/core/errors";
+import { Actor, ManualRecord } from "@/core/models";
+import { ManualRecordRepository } from "@/core/repositories";
+import { Unsubscriber } from "@/core/services";
+
+import { ManualRecordServiceImpl } from "@/services/manual-record";
+
+import { v4 as uuidv4 } from "uuid";
+
+const mockManualRecordRepo: jest.Mocked<ManualRecordRepository> = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getByParticipantId: jest.fn(),
+};
+
+const generateDummyManualRecord = (
+  participantId: string,
+  value: number = Math.floor(Math.random() * 10000),
+  recorderName: string = "테스트 계수자"
+): ManualRecord => ({
+  id: uuidv4(),
+  participantId,
+  value,
+  recorderName,
+  createdAt: new Date(),
+});
+
+describe("ManualRecordService 구현체 단위 테스트", () => {
+  let service: ManualRecordServiceImpl;
+  let adminActor: Actor;
+  let manualRecorderActor: Actor;
+  let anonymousActor: Actor;
+
+  beforeAll(() => {
+    // Arrange - 테스트용 액터들 생성
+    adminActor = {
+      id: uuidv4(),
+      name: "관리자",
+      roles: ["administrator"],
+      createdAt: new Date(),
+    };
+    manualRecorderActor = {
+      id: uuidv4(),
+      name: "수동 계수자",
+      roles: ["manualRecorder"],
+      createdAt: new Date(),
+    };
+    anonymousActor = {
+      id: uuidv4(),
+      name: "익명 사용자",
+      roles: [],
+      createdAt: new Date(),
+    };
+  });
+
+  beforeEach(() => {
+    // Arrange - 각 테스트 전에 모의 객체 초기화
+    jest.clearAllMocks();
+    service = new ManualRecordServiceImpl({
+      manualRecordRepository: mockManualRecordRepo,
+    });
+  });
+
+  it("아무나 특정 참가자의 수동 계수 기록을 조회할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const manualRecords: ManualRecord[] = [];
+    for (let i = 0; i < 5; i++) {
+      manualRecords.push(generateDummyManualRecord(participantId));
+    }
+    mockManualRecordRepo.getByParticipantId.mockResolvedValue(manualRecords);
+
+    // Act
+    const result = await service.getManualRecords(
+      anonymousActor,
+      participantId
+    );
+
+    // Assert
+    expect(result).toEqual(manualRecords);
+    expect(mockManualRecordRepo.getByParticipantId).toHaveBeenCalledWith(
+      participantId
+    );
+  });
+
+  it("관리자와 수동 계수자만 수동 계수 기록을 추가할 수 있다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const value = 5000;
+    const recorderName = "테스트 계수자";
+    const manualRecord = generateDummyManualRecord(
+      participantId,
+      value,
+      recorderName
+    );
+    mockManualRecordRepo.create.mockResolvedValue(manualRecord);
+
+    // Act & Assert - 익명 사용자는 권한 없음
+    await expect(
+      service.addManualRecord(
+        anonymousActor,
+        participantId,
+        value,
+        recorderName
+      )
+    ).rejects.toThrow(AuthorizationError);
+
+    // Act & Assert - 관리자는 권한 있음
+    await expect(
+      service.addManualRecord(adminActor, participantId, value, recorderName)
+    ).resolves.toBe(manualRecord);
+
+    // Act & Assert - 수동 계수자는 권한 있음
+    await expect(
+      service.addManualRecord(
+        manualRecorderActor,
+        participantId,
+        value,
+        recorderName
+      )
+    ).resolves.toBe(manualRecord);
+  });
+
+  it("수동 계수 기록 추가 시 올바른 데이터가 저장된다.", async () => {
+    // Arrange
+    const participantId = uuidv4();
+    const value = 7500;
+    const recorderName = "김계수";
+    const manualRecord = generateDummyManualRecord(
+      participantId,
+      value,
+      recorderName
+    );
+    mockManualRecordRepo.create.mockResolvedValue(manualRecord);
+
+    // Act
+    const result = await service.addManualRecord(
+      adminActor,
+      participantId,
+      value,
+      recorderName
+    );
+
+    // Assert
+    expect(result).toEqual(manualRecord);
+    expect(mockManualRecordRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participantId,
+        value,
+        recorderName,
+        createdAt: expect.any(Date),
+      })
+    );
+  });
+
+  describe("수동 계수 기록 추가 이벤트 구독 테스트", () => {
+    let participantId: string;
+    let callback1Unsubscriber: Unsubscriber;
+    let callback2Unsubscriber: Unsubscriber;
+    let callback1: jest.Mock;
+    let callback2: jest.Mock;
+
+    beforeEach(() => {
+      // Arrange
+      participantId = uuidv4();
+      callback1 = jest.fn();
+      callback2 = jest.fn();
+      callback1Unsubscriber = service.subscribeManualRecordAdded(
+        participantId,
+        callback1
+      );
+      callback2Unsubscriber = service.subscribeManualRecordAdded(
+        participantId,
+        callback2
+      );
+    });
+
+    afterEach(() => {
+      callback1Unsubscriber();
+      callback2Unsubscriber();
+      jest.clearAllMocks();
+    });
+
+    it("수동 계수 기록이 추가되면 모든 구독자에게 알림을 보낸다.", async () => {
+      // Arrange
+      const manualRecord = generateDummyManualRecord(participantId);
+      mockManualRecordRepo.create.mockResolvedValue(manualRecord);
+
+      // Act
+      await service.addManualRecord(
+        adminActor,
+        participantId,
+        1000,
+        "테스트 계수자"
+      );
+
+      // Assert
+      expect(callback1).toHaveBeenCalledWith(manualRecord);
+      expect(callback2).toHaveBeenCalledWith(manualRecord);
+    });
+
+    it("구독 함수에서 오류가 발생해도 서비스 로직은 정상적으로 동작한다.", async () => {
+      // Arrange
+      const manualRecord = generateDummyManualRecord(participantId);
+      mockManualRecordRepo.create.mockResolvedValue(manualRecord);
+      callback1.mockRejectedValue(
+        new Error("에러가 발생해도 서비스 로직은 정상적으로 동작해야 해요.")
+      );
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      // Act
+      const asyncTask = service.addManualRecord(
+        adminActor,
+        participantId,
+        1000,
+        "테스트 계수자"
+      );
+
+      // Assert
+      await expect(asyncTask).resolves.toBe(manualRecord);
+      expect(callback1).toHaveBeenCalledWith(manualRecord);
+      expect(callback2).toHaveBeenCalledWith(manualRecord);
+
+      // Cleanup
+      errorSpy.mockRestore();
+    });
+
+    it("구독을 해제하면 더 이상 이벤트를 받지 않는다.", async () => {
+      // Arrange
+      const manualRecord = generateDummyManualRecord(participantId);
+      mockManualRecordRepo.create.mockResolvedValue(manualRecord);
+      callback1Unsubscriber();
+
+      // Act
+      await service.addManualRecord(
+        manualRecorderActor,
+        participantId,
+        1000,
+        "테스트 계수자"
+      );
+
+      // Assert
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledWith(manualRecord);
+    });
+  });
+});


### PR DESCRIPTION
Closes #37 

## 변경 사항
- ManualRecord에 invalidatedAt 필드 제거
- ManualRecordService 구현체 추가
- 수동 계수 기록 API 추가
  - GET `/participants/{participantId}/manual-records`: 특정 참가자 수동 계수 기록 확인
  - POST `/participants/{participantId}/manual-records`: 특정 참가자 수동 계수 기록 추가