### PR TITLE
참가자 추가 및 대회 부문 상태 직접 변경 제한

### DIFF
--- a/server/src/container.ts
+++ b/server/src/container.ts
@@ -134,6 +134,7 @@ export class Container {
       this.competitionService
     );
     this.participantService = new ParticipantService({
+      divisionRepository: this.divisionSQLiteRepo,
       participantRepository: this.participantSQLiteRepo,
       recordRepository: this.recordSQLiteRepo,
       manualRecordRepository: this.manualRecordSQLiteRepo,

--- a/server/src/core/errors.ts
+++ b/server/src/core/errors.ts
@@ -54,13 +54,6 @@ export class DivisionStatusError extends Error {
   }
 }
 
-export class DivisionNotOngoingError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DivisionNotOngoingError";
-  }
-}
-
 export class RunnerNotParticipatedError extends Error {
   constructor(message: string) {
     super(message);

--- a/server/src/core/errors.ts
+++ b/server/src/core/errors.ts
@@ -47,6 +47,13 @@ export class TimerLogConsecutiveError extends Error {
   }
 }
 
+export class DivisionStatusError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DivisionStatusError";
+  }
+}
+
 export class DivisionNotOngoingError extends Error {
   constructor(message: string) {
     super(message);

--- a/server/src/core/services/competition.actor.ts
+++ b/server/src/core/services/competition.actor.ts
@@ -1,4 +1,4 @@
-import { Actor, Division } from "@/core/models";
+import { Actor } from "@/core/models";
 import { requireAnyRole } from "@/core/utils/auth";
 
 import { CompetitionService } from "./competition";
@@ -62,15 +62,6 @@ export class CompetitionActorService {
   public async deleteDivision(actor: Actor, divisionId: string) {
     requireAnyRole(actor, "administrator");
     return this.service.deleteDivision(divisionId);
-  }
-
-  public async setDivisionStatus(
-    actor: Actor,
-    divisionId: string,
-    status: Division["status"]
-  ) {
-    requireAnyRole(actor, "administrator");
-    return this.service.setDivisionStatus(divisionId, status);
   }
 
   public async getTopRecordsByDivision(actor: Actor, divisionId: string) {

--- a/server/src/core/services/division-progress.ts
+++ b/server/src/core/services/division-progress.ts
@@ -1,5 +1,5 @@
 import {
-  DivisionNotOngoingError,
+  DivisionStatusError,
   RunnerNotParticipatedError,
   RunnerNotSetError,
 } from "@/core/errors";
@@ -97,23 +97,21 @@ export class DivisionProgressService {
 
   /**
    * 부문이 "ongoing" 상태인지 검증하고 부문 데이터를 반환한다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
    */
   private async getDivisionAndCheckOngoing(
     divisionId: string
   ): Promise<Division> {
     const division = await this.competitionSrv.getDivision(divisionId);
     if (division.status !== "ongoing") {
-      throw new DivisionNotOngoingError(
-        `Division ${divisionId} is not ongoing`
-      );
+      throw new DivisionStatusError(`Division ${divisionId} is not ongoing`);
     }
     return division;
   }
 
   /**
    * 부문의 현재 활성 경연자를 설정한다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotParticipatedError 경연자가 참가자 목록에 없는 경우
    */
   public async setRunner(divisionId: string, runnerId: string) {
@@ -156,7 +154,7 @@ export class DivisionProgressService {
 
   /**
    * 현재 경연자를 대기열의 마지막으로 미루고 다음 경연자로 넘어간다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotSetError 현재 설정된 경연자가 없는 경우
    */
   public async postponeRunner(divisionId: string) {
@@ -200,7 +198,7 @@ export class DivisionProgressService {
 
   /**
    * 대회 대기열에서 특정 참가자의 순서 위치를 변경한다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotParticipatedError 참가자가 부문에 없는 경우
    */
   public async changeParticipantOrder(
@@ -235,7 +233,7 @@ export class DivisionProgressService {
 
   /**
    * 전반적인 부문 진행 정보를 조회한다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
    */
   public async getDivisionProgress(
     divisionId: string

--- a/server/src/core/services/participant.ts
+++ b/server/src/core/services/participant.ts
@@ -1,7 +1,8 @@
-import { TimerLogConsecutiveError } from "@/core/errors";
+import { DivisionStatusError, TimerLogConsecutiveError } from "@/core/errors";
 import { Unsubscriber } from "@/core/interfaces";
 import { ManualRecord, Participant, Record, TimerLog } from "@/core/models";
 import {
+  DivisionRepository,
   ManualRecordRepository,
   ParticipantRepository,
   RecordRepository,
@@ -37,17 +38,20 @@ export type ParticipantEventCallback = (
 ) => Promise<void>;
 
 export class ParticipantService {
+  private readonly divisionRepo: DivisionRepository;
   private readonly participantRepo: ParticipantRepository;
   private readonly recordRepo: RecordRepository;
   private readonly manualRecordRepo: ManualRecordRepository;
   private readonly timerLogRepo: TimerLogRepository;
 
   constructor(di: {
+    divisionRepository: DivisionRepository;
     participantRepository: ParticipantRepository;
     manualRecordRepository: ManualRecordRepository;
     recordRepository: RecordRepository;
     timerLogRepository: TimerLogRepository;
   }) {
+    this.divisionRepo = di.divisionRepository;
     this.participantRepo = di.participantRepository;
     this.recordRepo = di.recordRepository;
     this.manualRecordRepo = di.manualRecordRepository;
@@ -66,6 +70,11 @@ export class ParticipantService {
     orderRaw: number,
     givenTime: number
   ): Promise<Participant> {
+    const division = await this.divisionRepo.getById(divisionId);
+    if (division.status !== "ready") {
+      throw new DivisionStatusError(`Division ${divisionId} is not ready`);
+    }
+
     const participant: Participant = {
       id: uuidv4(),
       divisionId,

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -80,26 +80,6 @@ export class DivisionController {
     await this.competitionService.deleteDivision(actor, divisionId);
   }
 
-  @Patch("/:divisionId/status")
-  @ApiActorSecurity()
-  @ApiResponse({
-    status: 200,
-    description: "대회 부문 상태 수정 성공 및 대회 부문 정보 반환",
-    type: DivisionResponseDto,
-  })
-  async setDivisionStatus(
-    @CurrentActor() actor: Actor,
-    @Param("divisionId") divisionId: string,
-    @Body() body: SetDivisionStatusDto
-  ): Promise<DivisionResponseDto> {
-    const updated = await this.competitionService.setDivisionStatus(
-      actor,
-      divisionId,
-      body.status
-    );
-    return updated;
-  }
-
   @Get("/:divisionId/participants")
   @ApiResponse({
     status: 200,

--- a/server/src/http/exception.filter.ts
+++ b/server/src/http/exception.filter.ts
@@ -2,7 +2,6 @@ import {
   AuthenticationError,
   AuthorizationError,
   CounterNotRegisteredError,
-  DivisionNotOngoingError,
   DivisionStatusError,
   EntityNotFoundError,
   ParameterInvalidError,
@@ -100,13 +99,6 @@ export class CustomExceptionFilter implements ExceptionFilter {
         error = {
           statusCode: HttpStatus.BAD_REQUEST,
           type: "DivisionStatusError",
-          message: exception.message,
-        };
-        break;
-      case exception instanceof DivisionNotOngoingError:
-        error = {
-          statusCode: HttpStatus.BAD_REQUEST,
-          type: "DivisionNotOngoingError",
           message: exception.message,
         };
         break;

--- a/server/src/http/exception.filter.ts
+++ b/server/src/http/exception.filter.ts
@@ -3,6 +3,7 @@ import {
   AuthorizationError,
   CounterNotRegisteredError,
   DivisionNotOngoingError,
+  DivisionStatusError,
   EntityNotFoundError,
   ParameterInvalidError,
   PersistenceError,
@@ -92,6 +93,13 @@ export class CustomExceptionFilter implements ExceptionFilter {
         error = {
           statusCode: HttpStatus.BAD_REQUEST,
           type: "TimerLogConsecutiveError",
+          message: exception.message,
+        };
+        break;
+      case exception instanceof DivisionStatusError:
+        error = {
+          statusCode: HttpStatus.BAD_REQUEST,
+          type: "DivisionStatusError",
           message: exception.message,
         };
         break;

--- a/server/tests/unit/services/division-progress.test.ts
+++ b/server/tests/unit/services/division-progress.test.ts
@@ -1,5 +1,5 @@
 import {
-  DivisionNotOngoingError,
+  DivisionStatusError,
   RunnerNotParticipatedError,
   RunnerNotSetError,
 } from "@/core/errors";
@@ -278,7 +278,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.setRunner(division.id, runnerId);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
+      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
     });
   });
 
@@ -392,7 +392,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.postponeRunner(division.id);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
+      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
     });
   });
 
@@ -490,7 +490,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.changeParticipantOrder(division.id, "0", 3);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
+      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
       expect(mockStateStore.setState).not.toHaveBeenCalled();
     });
   });
@@ -554,7 +554,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.getDivisionProgress(division.id);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
+      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
     });
   });
 

--- a/server/tests/unit/services/participant.test.ts
+++ b/server/tests/unit/services/participant.test.ts
@@ -1,6 +1,13 @@
-import { TimerLogConsecutiveError } from "@/core/errors";
-import { ManualRecord, Participant, Record, TimerLog } from "@/core/models";
+import { DivisionStatusError, TimerLogConsecutiveError } from "@/core/errors";
 import {
+  Division,
+  ManualRecord,
+  Participant,
+  Record,
+  TimerLog,
+} from "@/core/models";
+import {
+  DivisionRepository,
   ManualRecordRepository,
   ParticipantRepository,
   RecordRepository,
@@ -9,6 +16,14 @@ import {
 import { ParticipantService } from "@/core/services/participant";
 
 import { v4 as uuidv4 } from "uuid";
+
+const mockDivisionRepo: jest.Mocked<DivisionRepository> = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getByCompetitionId: jest.fn(),
+};
 
 const mockParticipantRepo: jest.Mocked<ParticipantRepository> = {
   getById: jest.fn(),
@@ -41,6 +56,15 @@ const mockTimerLogRepo: jest.Mocked<TimerLogRepository> = {
   delete: jest.fn(),
   getByParticipantId: jest.fn(),
 };
+
+const generateDivision = (name: string): Division => ({
+  id: uuidv4(),
+  competitionId: uuidv4(),
+  name,
+  description: `${name} 설명`,
+  createdAt: new Date(),
+  status: "ready",
+});
 
 const generateDummyParticipant = (
   count: number,
@@ -100,6 +124,7 @@ describe("ParticipantService 단위 테스트", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     service = new ParticipantService({
+      divisionRepository: mockDivisionRepo,
       participantRepository: mockParticipantRepo,
       recordRepository: mockRecordRepo,
       manualRecordRepository: mockManualRecordRepo,
@@ -129,8 +154,10 @@ describe("ParticipantService 단위 테스트", () => {
 
     it("참가자를 추가할 수 있다.", async () => {
       // Arrange
-      const participant = generateDummyParticipant(0, uuidv4());
+      const division = generateDivision("부문 1");
+      const participant = generateDummyParticipant(0, division.id);
       mockParticipantRepo.create.mockResolvedValue(participant);
+      mockDivisionRepo.getById.mockResolvedValue(division);
 
       // Act
       const result = await service.addParticipant(
@@ -156,6 +183,34 @@ describe("ParticipantService 단위 테스트", () => {
           givenTime: participant.givenTime,
         })
       );
+      expect(mockDivisionRepo.getById).toHaveBeenCalledWith(
+        participant.divisionId
+      );
+    });
+
+    it("준비 상태가 아닌 부문에 참가자를 추가할 수 없다.", async () => {
+      // Arrange
+      const division = generateDivision("부문 1");
+      const participant = generateDummyParticipant(0, division.id);
+      mockDivisionRepo.getById.mockResolvedValue({
+        ...division,
+        status: "ongoing",
+      });
+
+      // Act
+      const asyncTask = service.addParticipant(
+        participant.divisionId,
+        participant.name,
+        participant.teamName,
+        participant.robotName,
+        participant.comment,
+        participant.orderRaw,
+        participant.givenTime
+      );
+
+      // Assert
+      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      expect(mockParticipantRepo.create).not.toHaveBeenCalled();
     });
 
     it("특정 참가자를 조회할 수 있다.", async () => {


### PR DESCRIPTION
Closes #54 

## 변경 사항
1. 대회 부문 상태 변경 API `PATCH /:divisionId/status` 제거
    - 직접 대회 부문 상태를 변경하기 보다는,
      - `POST /divisions/{divisionId}/progress/open`
      - `POST /divisions/{divisionId}/progress/close`
      - `POST /divisions/{divisionId}/progress/reset`
      - API를 이용하여 대회 부문 상태를 변경시키도록 하여 DivisionProgress 상태도 함께 관리하도록 하고자 함.
2. 대회 부문 상태가 `ready`가 아니면 해당 대회 부문에 참가자를 추가할 수 없도록 수정.
    - 진행 중인 대회에 참가자를 추가할 수 없기 때문.
3. 대회 부문 상태 관련 오류는 모두 `DivisionStatusError` 에러 클래스로 처리하도록 수정.