### PR TITLE
RESTful API 설계 적용 및 Swagger 개선

### DIFF
--- a/server/src/core/models.ts
+++ b/server/src/core/models.ts
@@ -71,7 +71,7 @@ export interface TimerLog {
 }
 
 export interface Counter {
-  id: string; // 계수기 ID
+  deviceId: string; // 계수기 ID
   name: string; // 계수기 이름
   startedAt: number | null; // 시작 시각(unix timestamp, null이면 아직 시작되지 않음을 의미함)
   stoppedAt: number | null; // 종료 시각(unix timestamp, null이면 아직 종료되지 않음을 의미함)

--- a/server/src/core/services/competition.actor.ts
+++ b/server/src/core/services/competition.actor.ts
@@ -40,6 +40,10 @@ export class CompetitionActorService {
     return this.service.deleteCompetition(competitionId);
   }
 
+  public async getDivision(actor: Actor, divisionId: string) {
+    return this.service.getDivision(divisionId);
+  }
+
   public async createDivision(
     actor: Actor,
     competitionId: string,

--- a/server/src/core/services/counter.ts
+++ b/server/src/core/services/counter.ts
@@ -64,7 +64,7 @@ export class CounterService {
       this.counterDivisionBindingMap.get(deviceId)?.divisionId ?? null;
 
     return {
-      id: deviceId,
+      deviceId,
       name,
       startedAt,
       stoppedAt,

--- a/server/src/http/controllers/actor.controller.ts
+++ b/server/src/http/controllers/actor.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   Inject,
   Param,
+  Patch,
   Post,
   Req,
 } from "@nestjs/common";
@@ -38,6 +39,7 @@ export class ActorController {
   ) {}
 
   @Get("/")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
@@ -72,6 +74,7 @@ export class ActorController {
   }
 
   @Post("/login")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "로그인 성공 및 세션 키 반환",
@@ -92,6 +95,7 @@ export class ActorController {
   }
 
   @Get("/whoami")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
@@ -110,7 +114,7 @@ export class ActorController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "서버에 저장된 세션 키 폐기(또는 없음)",
+    description: "서버에 저장된 세션 키 폐기",
   })
   async logoutActor(
     @Req()
@@ -122,7 +126,7 @@ export class ActorController {
     }
   }
 
-  @Post("/:actorId/roles")
+  @Patch("/:actorId/roles")
   @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({

--- a/server/src/http/controllers/competition.controller.ts
+++ b/server/src/http/controllers/competition.controller.ts
@@ -34,6 +34,7 @@ export class CompetitionController {
   ) {}
 
   @Get("/")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "모든 대회 목록 반환",
@@ -44,6 +45,7 @@ export class CompetitionController {
   }
 
   @Get("/:competitionId")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "대회 정보 반환",
@@ -83,11 +85,12 @@ export class CompetitionController {
   }
 
   @Patch("/:competitionId")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
     description: "대회 정보 수정 성공 및 수정된 대회 정보 반환",
-    type: UpdateCompetitionDto,
+    type: CompetitionResponseDto,
   })
   async updateCompetition(
     @CurrentActor() actor: Actor,
@@ -117,6 +120,7 @@ export class CompetitionController {
   }
 
   @Get("/:competitionId/divisions")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "대회에 속한 모든 부문 목록 반환",

--- a/server/src/http/controllers/counter.controller.ts
+++ b/server/src/http/controllers/counter.controller.ts
@@ -41,9 +41,10 @@ export class CounterController {
   ) {}
 
   @Get()
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
-    description: "모든 카운터 목록 반환",
+    description: "모든 계수기 목록 반환",
     type: [CounterResponseDto],
   })
   async getCounters(
@@ -53,9 +54,10 @@ export class CounterController {
   }
 
   @Get("/:deviceId")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
-    description: "특정 카운터 정보 반환",
+    description: "특정 계수기 정보 반환",
     type: CounterResponseDto,
   })
   async getCounter(
@@ -70,7 +72,7 @@ export class CounterController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "카운터를 특정 부문에 연결하거나 해제함",
+    description: "계수기를 특정 부문에 연결하거나 해제함",
   })
   async linkCounterToDivision(
     @CurrentActor() actor: Actor,
@@ -89,7 +91,7 @@ export class CounterController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "카운터를 부문에서 연결 해제 성공",
+    description: "계수기를 부문에서 연결 해제 성공",
   })
   async unlinkCounterFromDivision(
     @CurrentActor() actor: Actor,
@@ -103,7 +105,7 @@ export class CounterController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "카운터 리셋 성공",
+    description: "계수기 리셋 성공",
   })
   async resetCounter(
     @CurrentActor() actor: Actor,
@@ -117,7 +119,7 @@ export class CounterController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "카운터 등록 해제 성공",
+    description: "계수기 등록 해제 성공",
   })
   async unregisterCounter(
     @CurrentActor() actor: Actor,
@@ -127,11 +129,11 @@ export class CounterController {
   }
 
   @Post("/front-back-ir/register")
-  @HttpCode(201)
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 201,
-    description: "Front-Back IR 카운터 등록 성공",
+    status: 204,
+    description: "Front-Back IR 계수기 등록 성공",
   })
   async registerFrontBackIrCounter(
     @CurrentActor() actor: Actor,
@@ -152,7 +154,7 @@ export class CounterController {
   @ApiActorSecurity()
   @ApiResponse({
     status: 204,
-    description: "Front-Back IR 카운터 데이터 전송 성공",
+    description: "Front-Back IR 계수기 데이터 전송 성공",
   })
   @ApiBody({
     type: FrontBackIrCounterDeviceDataDto,

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -132,7 +132,8 @@ export class DivisionController {
     );
   }
 
-  @Get("/:divisionId/top-records")
+  @Get("/:divisionId/records/top")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 부문의 상위 기록 목록 반환",

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -25,7 +25,6 @@ import {
   DivisionProgressResponseDto,
   DivisionResponseDto,
   SetCurrentRunnerDto,
-  SetDivisionStatusDto,
   UpdateDivisionDto,
 } from "../dtos/division.dto";
 import {
@@ -45,6 +44,20 @@ export class DivisionController {
     @Inject("DivisionProgressService")
     private readonly divisionProgressService: DivisionProgressActorService
   ) {}
+
+  @Get("/:divisionId")
+  @HttpCode(200)
+  @ApiResponse({
+    status: 200,
+    description: "특정 대회 부문 정보 반환",
+    type: DivisionResponseDto,
+  })
+  async getDivision(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string
+  ): Promise<DivisionResponseDto> {
+    return this.competitionService.getDivision(actor, divisionId);
+  }
 
   @Patch("/:divisionId")
   @ApiActorSecurity()

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -60,11 +60,12 @@ export class DivisionController {
   }
 
   @Patch("/:divisionId")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
     description: "대회 부문 정보 수정 성공 및 대회 부문 정보 반환",
-    type: UpdateDivisionDto,
+    type: DivisionResponseDto,
   })
   async updateDivision(
     @CurrentActor() actor: Actor,
@@ -94,6 +95,7 @@ export class DivisionController {
   }
 
   @Get("/:divisionId/participants")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 부문의 모든 참가자 목록 반환",
@@ -147,6 +149,7 @@ export class DivisionController {
   }
 
   @Get("/:divisionId/progress")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 부문의 진행 상태 반환",
@@ -160,9 +163,10 @@ export class DivisionController {
   }
 
   @Post("/:divisionId/progress/open")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "대회 부문 시작 성공",
   })
   async openDivision(
@@ -173,9 +177,10 @@ export class DivisionController {
   }
 
   @Post("/:divisionId/progress/close")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "대회 부문 종료 성공",
   })
   async closeDivision(
@@ -186,9 +191,10 @@ export class DivisionController {
   }
 
   @Post("/:divisionId/progress/reset")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "대회 부문 초기화 성공",
   })
   async resetDivision(
@@ -199,9 +205,10 @@ export class DivisionController {
   }
 
   @Patch("/:divisionId/progress/runner")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "현재 경연자 설정 성공",
   })
   async setCurrentRunner(
@@ -217,9 +224,10 @@ export class DivisionController {
   }
 
   @Post("/:divisionId/progress/runner/postpone")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "현재 경연자 연기 성공",
   })
   async postponeCurrentRunner(
@@ -230,6 +238,7 @@ export class DivisionController {
   }
 
   @Get("/:divisionId/progress/order")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "참가자 순번 목록 반환",
@@ -243,9 +252,10 @@ export class DivisionController {
   }
 
   @Patch("/:divisionId/progress/order")
+  @HttpCode(204)
   @ApiActorSecurity()
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: "참가자 순번 변경 성공",
   })
   async setParticipantOrder(

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -13,7 +13,6 @@ import {
   Param,
   Patch,
   Post,
-  Query,
 } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 
@@ -22,6 +21,7 @@ import {
   CurrentActor,
 } from "../decorators/current-actor.decorator";
 import {
+  ChangeParticipantOrderDto,
   DivisionProgressResponseDto,
   DivisionResponseDto,
   SetCurrentRunnerDto,
@@ -251,14 +251,13 @@ export class DivisionController {
   async setParticipantOrder(
     @CurrentActor() actor: Actor,
     @Param("divisionId") divisionId: string,
-    @Query("participantId") participantId: string,
-    @Query("order") order: number
+    @Body() body: ChangeParticipantOrderDto
   ): Promise<void> {
     await this.divisionProgressService.changeParticipantOrder(
       actor,
       divisionId,
-      participantId,
-      order
+      body.participantId,
+      body.order
     );
   }
 }

--- a/server/src/http/controllers/participant.controller.ts
+++ b/server/src/http/controllers/participant.controller.ts
@@ -38,6 +38,7 @@ export class ParticipantController {
   ) {}
 
   @Patch("/:participantId")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
@@ -71,6 +72,7 @@ export class ParticipantController {
   }
 
   @Get("/:participantId/records")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 참가자의 모든 기록 목록 반환",
@@ -84,6 +86,7 @@ export class ParticipantController {
   }
 
   @Post("/:participantId/records")
+  @HttpCode(201)
   @ApiActorSecurity()
   @ApiResponse({
     status: 201,
@@ -105,6 +108,7 @@ export class ParticipantController {
   }
 
   @Get("/:participantId/manual-records")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 참가자의 모든 수동 계수 기록 목록 반환",
@@ -189,6 +193,7 @@ export class ParticipantController {
   }
 
   @Get("/:participantId/timer/logs")
+  @HttpCode(200)
   @ApiResponse({
     status: 200,
     description: "특정 참가자의 모든 타이머 로그 목록 반환",

--- a/server/src/http/controllers/record.controller.ts
+++ b/server/src/http/controllers/record.controller.ts
@@ -1,7 +1,14 @@
 import { Actor } from "@/core/models";
 import { ParticipantActorService } from "@/core/services/participant.actor";
 
-import { Body, Controller, Inject, Param, Patch } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Inject,
+  Param,
+  Patch,
+} from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import {
@@ -23,6 +30,7 @@ export class RecordController {
   ) {}
 
   @Patch("/:recordId/note")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
@@ -38,10 +46,11 @@ export class RecordController {
   }
 
   @Patch("/:recordId/status")
+  @HttpCode(200)
   @ApiActorSecurity()
   @ApiResponse({
     status: 200,
-    description: "기록 상태 변경 성공 및 변경된 기록 정보 반환",
+    description: "기록 상태 변경 성공 및 수정된 기록 정보 반환",
     type: RecordResponseDto,
   })
   async setRecordStatus(

--- a/server/src/http/dtos/counter.dto.ts
+++ b/server/src/http/dtos/counter.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
 import {
-  IsArray,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -14,7 +13,7 @@ import {
 
 export class CounterResponseDto {
   @ApiProperty({ description: "계수기 ID" })
-  id!: string;
+  deviceId!: string;
 
   @ApiProperty({ description: "계수기 이름", example: "Line Counter #1" })
   name!: string;
@@ -43,7 +42,7 @@ export class CounterResponseDto {
 
 export class CounterDivisionBindingDto {
   @ApiProperty({
-    description: "연결할 divisionId. 해제하려면 null.",
+    description: "연결할 대회 부문 ID(null이면 연결 해제)",
     type: String,
     nullable: true,
     example: "division-123",

--- a/server/src/http/dtos/division.dto.ts
+++ b/server/src/http/dtos/division.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsIn, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import {
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from "class-validator";
 
 import { CompetitionResponseDto } from "./competition.dto";
 import { ManualRecordResponseDto } from "./manual-record.dto";
@@ -106,4 +112,16 @@ export class SetCurrentRunnerDto {
   @IsString()
   @IsNotEmpty()
   participantId!: string;
+}
+
+export class ChangeParticipantOrderDto {
+  @ApiProperty({ description: "변경할 참가자의 참가자 ID" })
+  @IsString()
+  @IsNotEmpty()
+  participantId!: string;
+
+  @ApiProperty({ description: "변경할 참가자의 순번" })
+  @IsNumber()
+  @IsNotEmpty()
+  order!: number;
 }


### PR DESCRIPTION
Closes #56

## 주요 변경 사항
- Counter 모델의 `id` 속성을 `deviceId`로 변경함
  - Counter의 식별자는 실제 하드웨어에서 제공한다는 점을 강조하기 위함
- `GET /divisions/{divisionId}` API 추가 - 개별 대회 부문에 대한 정보를 가져올 수 있음
- `GET /divisions/{divisionId}/top-records` API를 `GET /divisions/{divisionId}/records/top`으로 변경
- `POST /actors/{actorId}/roles` API를 `PATCH /actors/{actorId}/roles`으로 변경
- `PATCH /divisions/{divisionId}/progress/order` 파라미터를 Query가 아닌 Body(JSON)로 받도록 수정

## 사소한 개선 사항
- `PATCH /divisions/{divisionId}` Swagger 응답 형식을 `DivisionResponseDto`로 변경
- `PATCH /competitions/{competitionId}` Swagger 응답 형식을 `CompetitionResponseDto`로 변경
- 모든 HTTP Method 및 스웨거 문서 설명 개선