### PR TITLE
fix: CounterService 단위 테스트 실패 해결(id 필드를 deviceId 필드로 변경)

### DIFF
--- a/server/tests/unit/services/counter.test.ts
+++ b/server/tests/unit/services/counter.test.ts
@@ -59,14 +59,14 @@ describe("CounterService 단위 테스트", () => {
       // Assert
       expect(result).toEqual([
         {
-          id: "counter-001",
+          deviceId: "counter-001",
           name: "Test Counter",
           startedAt: null,
           stoppedAt: null,
           divisionId: null,
         },
         {
-          id: "counter-002",
+          deviceId: "counter-002",
           name: "Test Counter 2",
           startedAt: 1000,
           stoppedAt: 2000,
@@ -91,7 +91,7 @@ describe("CounterService 단위 테스트", () => {
 
       // Assert
       expect(result).toEqual({
-        id: "counter-001",
+        deviceId: "counter-001",
         name: "Test Counter",
         startedAt: 1000,
         stoppedAt: 2000,


### PR DESCRIPTION
Closes #64 

- #56 에서 `Counter` 모델에 대한 리팩토링이 있었는데,
- 분명 `id` 필드를 `deviceId` 필드로 변경하고 테스트 돌렸을 때 잘 통과한 것 같았는데,
- 다시 확인해보니 테스트에 실패했네요.
- 변명이겠죠. 다음부터 잘 확인하겠습니다.