### PR TITLE
미들웨어에서 발생한 예외를 전역 예외 필터에서 처리하도록 수정

### DIFF
--- a/server/src/http/middlewares/actor-session.middleware.ts
+++ b/server/src/http/middlewares/actor-session.middleware.ts
@@ -19,26 +19,22 @@ export class ActorSessionMiddleware implements NestMiddleware {
   ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
-    try {
-      const authHeader = req.headers.authorization;
-      const sessionKey = authHeader?.split(" ")[1];
+    const authHeader = req.headers.authorization;
+    const sessionKey = authHeader?.split(" ")[1];
 
-      // TODO: 추후 유틸리티 함수로 분리할 것
-      let actor: Actor = {
-        id: "",
-        name: "익명 사용자",
-        roles: [],
-        createdAt: new Date(),
-      };
-      if (sessionKey) {
-        actor = await this.actorSessionStore.validateSession(sessionKey);
-        req.actorSessionKey = sessionKey;
-      }
-
-      req.actor = actor;
-      next();
-    } catch (err) {
-      next(err);
+    // TODO: 추후 유틸리티 함수로 분리할 것
+    let actor: Actor = {
+      id: "",
+      name: "익명 사용자",
+      roles: [],
+      createdAt: new Date(),
+    };
+    if (sessionKey) {
+      actor = await this.actorSessionStore.validateSession(sessionKey);
+      req.actorSessionKey = sessionKey;
     }
+
+    req.actor = actor;
+    next();
   }
 }


### PR DESCRIPTION
Closes #79

## 변경 사항
- 미들웨어에서 발생한 오류를 next()로 넘겨주니 NestJS의 컨트롤러를 타지 않아 404 Not Found가 뜨는 문제점 파악
- 미들웨어에서 오류가 발생하더라도 try-catch해주지 않고 기존에 존재하던 전역 예외 처리 필터가 처리하도록 미들웨어 내 try-catch 제거