### PR TITLE
대회 부문 상태를 언제든 조회 및 구독할 수 있도록 변경

### DIFF
--- a/server/src/core/errors.ts
+++ b/server/src/core/errors.ts
@@ -47,10 +47,17 @@ export class TimerLogConsecutiveError extends Error {
   }
 }
 
-export class DivisionStatusError extends Error {
+export class DivisionNotOngoingError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "DivisionStatusError";
+    this.name = "DivisionNotOngoingError";
+  }
+}
+
+export class DivisionNotReadyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DivisionNotReadyError";
   }
 }
 

--- a/server/src/core/services/division-progress.ts
+++ b/server/src/core/services/division-progress.ts
@@ -240,13 +240,12 @@ export class DivisionProgressService {
 
   /**
    * 전반적인 부문 진행 정보를 조회한다.
-   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    */
   public async getDivisionProgress(
     divisionId: string
   ): Promise<DivisionProgress> {
     // 부문 및 대회 정보 조회
-    const division = await this.getDivisionAndCheckOngoing(divisionId);
+    const division = await this.competitionSrv.getDivision(divisionId);
     const competition = await this.competitionSrv.getCompetition(
       division.competitionId
     );

--- a/server/src/core/services/division-progress.ts
+++ b/server/src/core/services/division-progress.ts
@@ -1,5 +1,5 @@
 import {
-  DivisionStatusError,
+  DivisionNotOngoingError,
   RunnerNotParticipatedError,
   RunnerNotSetError,
 } from "@/core/errors";
@@ -97,21 +97,23 @@ export class DivisionProgressService {
 
   /**
    * 부문이 "ongoing" 상태인지 검증하고 부문 데이터를 반환한다.
-   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    */
   private async getDivisionAndCheckOngoing(
     divisionId: string
   ): Promise<Division> {
     const division = await this.competitionSrv.getDivision(divisionId);
     if (division.status !== "ongoing") {
-      throw new DivisionStatusError(`Division ${divisionId} is not ongoing`);
+      throw new DivisionNotOngoingError(
+        `Division ${divisionId} is not ongoing`
+      );
     }
     return division;
   }
 
   /**
    * 부문의 현재 활성 경연자를 설정한다.
-   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotParticipatedError 경연자가 참가자 목록에 없는 경우
    */
   public async setRunner(divisionId: string, runnerId: string) {
@@ -129,6 +131,11 @@ export class DivisionProgressService {
     await this.onStateChanged(divisionId, newState);
   }
 
+  /**
+   * 현재 경연자에 기록을 추가한다.
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
+   * @throws RunnerNotSetError 현재 설정된 경연자가 없는 경우
+   */
   public async addRecordToRunner(
     divisionId: string,
     value: number,
@@ -154,7 +161,7 @@ export class DivisionProgressService {
 
   /**
    * 현재 경연자를 대기열의 마지막으로 미루고 다음 경연자로 넘어간다.
-   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotSetError 현재 설정된 경연자가 없는 경우
    */
   public async postponeRunner(divisionId: string) {
@@ -198,7 +205,7 @@ export class DivisionProgressService {
 
   /**
    * 대회 대기열에서 특정 참가자의 순서 위치를 변경한다.
-   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    * @throws RunnerNotParticipatedError 참가자가 부문에 없는 경우
    */
   public async changeParticipantOrder(
@@ -233,7 +240,7 @@ export class DivisionProgressService {
 
   /**
    * 전반적인 부문 진행 정보를 조회한다.
-   * @throws DivisionStatusError 부문이 진행 중 상태가 아닌 경우
+   * @throws DivisionNotOngoingError 부문이 진행 중 상태가 아닌 경우
    */
   public async getDivisionProgress(
     divisionId: string

--- a/server/src/core/services/participant.ts
+++ b/server/src/core/services/participant.ts
@@ -1,4 +1,4 @@
-import { DivisionStatusError, TimerLogConsecutiveError } from "@/core/errors";
+import { DivisionNotReadyError, TimerLogConsecutiveError } from "@/core/errors";
 import { Unsubscriber } from "@/core/interfaces";
 import { ManualRecord, Participant, Record, TimerLog } from "@/core/models";
 import {
@@ -71,7 +71,9 @@ export class ParticipantService {
   ): Promise<Participant> {
     const division = await this.divisionRepo.getById(divisionId);
     if (division.status !== "ready") {
-      throw new DivisionStatusError(`Division ${divisionId} is not ready`);
+      throw new DivisionNotReadyError(
+        `Division ${divisionId} is not ready to add participant`
+      );
     }
 
     const participant: Participant = {

--- a/server/src/http/exception.filter.ts
+++ b/server/src/http/exception.filter.ts
@@ -2,7 +2,8 @@ import {
   AuthenticationError,
   AuthorizationError,
   CounterNotRegisteredError,
-  DivisionStatusError,
+  DivisionNotOngoingError,
+  DivisionNotReadyError,
   EntityNotFoundError,
   ParameterInvalidError,
   PersistenceError,
@@ -95,10 +96,17 @@ export class CustomExceptionFilter implements ExceptionFilter {
           message: exception.message,
         };
         break;
-      case exception instanceof DivisionStatusError:
+      case exception instanceof DivisionNotOngoingError:
         error = {
           statusCode: HttpStatus.BAD_REQUEST,
-          type: "DivisionStatusError",
+          type: "DivisionNotOngoingError",
+          message: exception.message,
+        };
+        break;
+      case exception instanceof DivisionNotReadyError:
+        error = {
+          statusCode: HttpStatus.BAD_REQUEST,
+          type: "DivisionNotReadyError",
           message: exception.message,
         };
         break;

--- a/server/tests/unit/services/division-progress.test.ts
+++ b/server/tests/unit/services/division-progress.test.ts
@@ -544,18 +544,6 @@ describe("DivisionProgressService 단위 테스트", () => {
         topRecords,
       });
     });
-
-    it("ongoing 상태가 아닌 부문의 진행 상태는 조회할 수 없다.", async () => {
-      // Arrange
-      const division = generateDummyDivision(uuidv4(), "ready");
-      mockCompetitionService.getDivision.mockResolvedValue(division);
-
-      // Act
-      const asyncTask = service.getDivisionProgress(division.id);
-
-      // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
-    });
   });
 
   describe("subscribeDivisionProgress", () => {

--- a/server/tests/unit/services/division-progress.test.ts
+++ b/server/tests/unit/services/division-progress.test.ts
@@ -1,5 +1,5 @@
 import {
-  DivisionStatusError,
+  DivisionNotOngoingError,
   RunnerNotParticipatedError,
   RunnerNotSetError,
 } from "@/core/errors";
@@ -278,7 +278,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.setRunner(division.id, runnerId);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
     });
   });
 
@@ -392,7 +392,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.postponeRunner(division.id);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
     });
   });
 
@@ -490,7 +490,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.changeParticipantOrder(division.id, "0", 3);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
       expect(mockStateStore.setState).not.toHaveBeenCalled();
     });
   });
@@ -554,7 +554,7 @@ describe("DivisionProgressService 단위 테스트", () => {
       const asyncTask = service.getDivisionProgress(division.id);
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      await expect(asyncTask).rejects.toThrow(DivisionNotOngoingError);
     });
   });
 

--- a/server/tests/unit/services/participant.test.ts
+++ b/server/tests/unit/services/participant.test.ts
@@ -1,4 +1,4 @@
-import { DivisionStatusError, TimerLogConsecutiveError } from "@/core/errors";
+import { DivisionNotReadyError, TimerLogConsecutiveError } from "@/core/errors";
 import {
   Division,
   ManualRecord,
@@ -206,7 +206,7 @@ describe("ParticipantService 단위 테스트", () => {
       );
 
       // Assert
-      await expect(asyncTask).rejects.toThrow(DivisionStatusError);
+      await expect(asyncTask).rejects.toThrow(DivisionNotReadyError);
       expect(mockParticipantRepo.create).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Closes #88 

## 변경 사항
- 언제든 대회 부문 상태를 조회할 수 있도록 변경

## 리팩토링
- `DivisionStatusError` 클래스 제거
- `DivisionNotOngoingError`: 대회가 진행 중인 상태에서만 행해야 하는 동작인데, `ongoing` 상태가 아니라면 발생하는 에러 추가
  - 경연자 설정, 경연자에 기록 추가, 경연자 연기, 참가자 순번 변경
- `DivisionNotReadyError`: 대회가 준비 상태에서만 행애져야 하는 동작인데, `ready` 상태가 아니라면 발생하는 에러 추가
  - 대회 부문에 참가자 추가