### PR TITLE
DivisionProgress 구독자 간 이벤트 전파 문제 해결

### DIFF
--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^@tests/(.*)$": "<rootDir>/tests/$1",
   },
+  testPathIgnorePatterns: ["<rootDir>/node_modules", "<rootDir>/build"],
 };
 
 export default config;

--- a/server/src/core/services/division-progress.actor.ts
+++ b/server/src/core/services/division-progress.actor.ts
@@ -63,11 +63,11 @@ export class DivisionProgressActorService {
     return this.service.getDivisionProgress(divisionId);
   }
 
-  public async subscribeDivisionProgress(
+  public subscribeDivisionProgress(
     actor: Actor,
     divisionId: string,
     callback: DivisionProgressCallback
-  ): Promise<Unsubscriber> {
+  ): Unsubscriber {
     return this.service.subscribeDivisionProgress(divisionId, callback);
   }
 }

--- a/server/src/core/services/division-progress.ts
+++ b/server/src/core/services/division-progress.ts
@@ -14,10 +14,28 @@ import {
   ParticipantEvent,
   ParticipantService,
 } from "@/core/services/participant";
+import EventEmitter from "events";
 
 export type DivisionProgressCallback = (
   progress: DivisionProgress
 ) => Promise<void>;
+
+type RunnerEvent =
+  | {
+      type: "runner-event";
+      participantId: string;
+      event: ParticipantEvent;
+    }
+  | {
+      type: "state-changed";
+      state: DivisionProgressState;
+    };
+
+interface RunnerEventEmitter extends EventEmitter {
+  on(divisionId: string, listener: (event: RunnerEvent) => void): this;
+  off(divisionId: string, listener: (event: RunnerEvent) => void): this;
+  emit(divisionId: string, event: RunnerEvent): boolean;
+}
 
 /**
  * 대회 부문 진행 상황 및 상태 관리 서비스
@@ -32,6 +50,7 @@ export class DivisionProgressService {
   private readonly competitionSrv: CompetitionService;
   private readonly participantSrv: ParticipantService;
   private readonly stateStore: DivisionProgressStateStore;
+  private readonly runnerEventEmitter: RunnerEventEmitter = new EventEmitter();
 
   constructor(di: {
     competitionService: CompetitionService;
@@ -128,7 +147,7 @@ export class DivisionProgressService {
 
     const newState = { ...state, runnerId };
     await this.stateStore.setState(divisionId, newState);
-    await this.onStateChanged(divisionId, newState);
+    this.onStateChanged(divisionId, newState);
   }
 
   /**
@@ -195,7 +214,7 @@ export class DivisionProgressService {
       participantOrder: newParticipantOrder,
     };
     await this.stateStore.setState(divisionId, newState);
-    await this.onStateChanged(divisionId, newState);
+    this.onStateChanged(divisionId, newState);
   }
 
   public async getParticipantOrder(divisionId: string): Promise<string[]> {
@@ -235,7 +254,7 @@ export class DivisionProgressService {
       participantOrder: newParticipantOrder,
     };
     await this.stateStore.setState(divisionId, newState);
-    await this.onStateChanged(divisionId, newState);
+    this.onStateChanged(divisionId, newState);
   }
 
   /**
@@ -291,81 +310,68 @@ export class DivisionProgressService {
   }
 
   /**
-   * 활성 부문 진행 감시자들의 레지스트리
-   * 부문 ID를 구독 상태 및 콜백에 매핑한다.
+   * 특정 부문에 대해 경연자의 이벤트를 구독해야 하는데, 그 구독 정보를 저장해두는 Map이다.
    */
   private runnerWatcher: Map<
     string, // divisionId
     {
-      readonly callback: DivisionProgressCallback; // 콜백 함수
       runnerId: string | null; // 현재 감시 중인 경연자 ID
       unsubscribe: Unsubscriber | null; // 참가자 이벤트 구독 해제 함수
     }
   > = new Map();
 
   /**
-   * 특정 경연자의 참가자 이벤트에 대한 구독을 생성한다.
+   * 경연자 이벤트를 구독 및 관리한다.
    *
-   * @param divisionId - 진행 컨텍스트를 위한 부문 식별자
-   * @param participantId - 이벤트를 모니터링할 참가자
-   * @param callback - 참가자 이벤트 발생 시 호출할 함수
-   * @returns 구독을 정리하기 위한 구독 해제 함수
+   * - 경연 부문의 현재 경연자가 설정되면 이 메서드를 호출하여 경연자 이벤트를 재구독해야 한다.
+   * - 경연자 이벤트가 발생하면 DivisionProgress 메시지 구독자에게 이벤트를 전달한다.
    */
-  private subscribeRunnerEvent(
-    divisionId: string,
-    participantId: string,
-    callback: DivisionProgressCallback
-  ): Unsubscriber {
-    return this.participantSrv.subscribeParticipantEvent(
-      participantId,
-      async (event: ParticipantEvent) => {
-        if (event.type === "deleted") {
-          return;
-        }
-        await callback(await this.getDivisionProgress(divisionId));
-      }
-    );
-  }
-
-  /**
-   * 구독을 업데이트하고 감시자들에게 알림으로 상태 변경을 처리한다.
-   *
-   * 부문 상태가 변경될 때 이 메서드는:
-   * - 업데이트된 진행 상황으로 등록된 콜백들에 알림
-   * - 경연자 이벤트 구독 관리 (기존 구독 해제, 새 구독 생성)
-   * - 활성 경연자가 없을 때 정리 작업 처리
-   *
-   * @param divisionId - 상태 변경이 발생한 부문
-   * @param state - 새로운 부문 진행 상태
-   */
-  private async onStateChanged(
-    divisionId: string,
-    state: DivisionProgressState
-  ) {
+  private watchRunner(divisionId: string, runnerId: string | null) {
     const watcher = this.runnerWatcher.get(divisionId);
-    if (!watcher) {
-      return; // 활성 감시자가 없으면 처리 건너뛰기
-    }
-    await watcher.callback(await this.getDivisionProgress(divisionId));
 
-    // 활성 경연자가 없을 때 구독 정리
-    if (state.runnerId === null) {
-      watcher.unsubscribe?.();
-      watcher.unsubscribe = null;
-      watcher.runnerId = null;
+    // 경연자 초기화 시 watcher 정리
+    if (runnerId === null) {
+      watcher?.unsubscribe?.();
+      this.runnerWatcher.delete(divisionId);
       return;
     }
 
-    // 경연자 변경 처리: 기존 구독 해제, 새 구독 생성
-    if (state.runnerId !== watcher.runnerId) {
-      watcher.unsubscribe?.();
-      watcher.unsubscribe = this.subscribeRunnerEvent(
-        divisionId,
-        state.runnerId,
-        watcher.callback
+    const subscribe = (runnerId: string) => {
+      return this.participantSrv.subscribeParticipantEvent(
+        runnerId,
+        async (event: ParticipantEvent) => {
+          this.runnerEventEmitter.emit(divisionId, {
+            type: "runner-event",
+            participantId: runnerId,
+            event,
+          });
+        }
       );
-      watcher.runnerId = state.runnerId;
+    };
+
+    if (!watcher) {
+      // watcher가 없는 경우 새로 구독
+      this.runnerWatcher.set(divisionId, {
+        runnerId,
+        unsubscribe: subscribe(runnerId),
+      });
+    } else if (watcher.runnerId !== runnerId) {
+      // 경연자 변경 시 watcher 구독 해제 및 새로 구독
+      watcher.unsubscribe?.();
+      watcher.unsubscribe = subscribe(runnerId);
+      watcher.runnerId = runnerId;
     }
+  }
+
+  /**
+   * 부문 상태 변경 시 이 메서드를 호출하여 이벤트 발생 및 경연자 감시 업데이트를 수행한다.
+   */
+  private onStateChanged(divisionId: string, state: DivisionProgressState) {
+    this.watchRunner(divisionId, state.runnerId);
+    this.runnerEventEmitter.emit(divisionId, {
+      type: "state-changed",
+      state,
+    });
   }
 
   /**
@@ -382,29 +388,36 @@ export class DivisionProgressService {
    * @param callback - 진행 데이터 변경 시 호출할 함수
    * @returns 모니터링을 중지하고 리소스를 정리하는 구독 해제 함수
    */
-  public async subscribeDivisionProgress(
+  public subscribeDivisionProgress(
     divisionId: string,
     callback: DivisionProgressCallback
-  ): Promise<Unsubscriber> {
-    const state = await this.stateStore.getState(divisionId);
-
+  ): Unsubscriber {
     // 구독 실패를 방지하기 위해 콜백을 에러 처리로 래핑
-    const safeCb = async (progress: DivisionProgress) => {
+    const safeCb = async () => {
       try {
+        const progress = await this.getDivisionProgress(divisionId);
         await callback(progress);
       } catch (e) {
         console.error(e);
       }
     };
 
-    // 경연자 이벤트 구독 추적 설정
-    this.runnerWatcher.set(divisionId, {
-      callback: safeCb,
-      runnerId: state.runnerId,
-      unsubscribe: state.runnerId
-        ? this.subscribeRunnerEvent(divisionId, state.runnerId, safeCb)
-        : null,
-    });
+    // 경연자의 상태 변경 이벤트 구독
+    this.runnerEventEmitter.on(divisionId, safeCb);
+
+    /**
+     * Lazy Watching
+     *
+     * 인스턴스 생성 시 부문 상태를 모두 조회하고 이벤트 구독하는 것이 비효율적이므로
+     * 이벤트 구독 시 경연자를 감시하도록 한다.
+     */
+    (async () => {
+      const watcher = this.runnerWatcher.get(divisionId);
+      if (!watcher) {
+        const state = await this.stateStore.getState(divisionId);
+        this.watchRunner(divisionId, state.runnerId);
+      }
+    })();
 
     // 부문 레벨 이벤트 구독 (상태 변경 등)
     const unsubscribeDivisionEvent = this.competitionSrv.subscribeDivisionEvent(
@@ -413,21 +426,14 @@ export class DivisionProgressService {
         if (event.type === "deleted") {
           return;
         }
-        await safeCb(await this.getDivisionProgress(event.division.id));
+        await safeCb();
       }
     );
 
     // 모든 구독을 제거하는 정리 함수 반환
     return () => {
-      // 부문 이벤트 구독 해제
-      unsubscribeDivisionEvent();
-
-      // 경연자 이벤트 구독 정리
-      const watcher = this.runnerWatcher.get(divisionId);
-      if (watcher) {
-        watcher.unsubscribe?.();
-        this.runnerWatcher.delete(divisionId);
-      }
+      this.runnerEventEmitter.off(divisionId, safeCb); // 경연자의 상태 변경 이벤트 구독 해제
+      unsubscribeDivisionEvent(); // 부문 이벤트 구독 해제
     };
   }
 }

--- a/server/src/http/gateways/division-progress.gateway.ts
+++ b/server/src/http/gateways/division-progress.gateway.ts
@@ -120,7 +120,7 @@ export class DivisionProgressGateway
 
       // 새로운 구독 생성
       const unsubscribe =
-        await this.divisionProgressService.subscribeDivisionProgress(
+        this.divisionProgressService.subscribeDivisionProgress(
           client.actor,
           divisionId,
           async (progress) => {

--- a/server/tests/unit/services/division-progress.test.ts
+++ b/server/tests/unit/services/division-progress.test.ts
@@ -582,6 +582,13 @@ describe("DivisionProgressService 단위 테스트", () => {
       );
     });
 
+    /**
+     * 비동기 작업 대기 `setTimeout` 계열 함수를 사용하여 microtask 큐가 모두 비워지고,
+     * macrotask 큐가 돌아간 후의 시점을 기다린다.
+     */
+    const flushMicrotasks = () =>
+      new Promise<void>((resolve) => setTimeout(resolve, 0));
+
     it("경연자를 바꿨을 때 기존 경연자에 대한 구독을 해제한다.", async () => {
       // Arrange
       const callback = jest.fn();
@@ -589,14 +596,10 @@ describe("DivisionProgressService 단위 테스트", () => {
       mockParticipantService.subscribeParticipantEvent.mockReturnValue(
         mockUnsubscribe
       );
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         callback
       );
-      mockStateStore.getState.mockResolvedValue({
-        ...meta,
-        runnerId: nextRunner.id,
-      });
 
       // Act
       await service.setRunner(division.id, nextRunner.id);
@@ -614,17 +617,16 @@ describe("DivisionProgressService 단위 테스트", () => {
     it("경연자를 바꿨을 때 바꾼 경연자에 대한 구독이 이루어진다.", async () => {
       // Arrange
       const callback = jest.fn();
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         callback
       );
-      mockStateStore.getState.mockResolvedValue({
-        ...meta,
-        runnerId: nextRunner.id,
-      });
 
       // Act
       await service.setRunner(division.id, nextRunner.id);
+
+      // Flush
+      await flushMicrotasks();
 
       // Assert
       expect(
@@ -639,17 +641,16 @@ describe("DivisionProgressService 단위 테스트", () => {
     it("참가자의 순서가 바뀌었을 때 콜백을 호출한다.", async () => {
       // Arrange
       const callback = jest.fn();
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         callback
       );
-      mockStateStore.getState.mockResolvedValue({
-        ...meta,
-        participantOrder: [runner.id, nextRunner.id, uuidv4()],
-      });
 
       // Act
       await service.changeParticipantOrder(division.id, nextRunner.id, 0);
+
+      // Flush
+      await flushMicrotasks();
 
       // Assert
       expect(callback).toHaveBeenCalled();
@@ -658,38 +659,42 @@ describe("DivisionProgressService 단위 테스트", () => {
       unsubscribe();
     });
 
-    it("참가자 이벤트(ParticipantEvent)가 발생하면 콜백을 호출한다.", async () => {
+    it("경연자에 이벤트(ParticipantEvent)가 발생하면 콜백을 호출한다.", async () => {
       // Arrange
       const callback = jest.fn();
-      let participantEventCallback: ParticipantEventCallback | undefined;
+      let runnerEventCallback: ParticipantEventCallback | undefined;
       mockParticipantService.subscribeParticipantEvent.mockImplementation(
         (id, cb) => {
-          participantEventCallback = cb;
+          runnerEventCallback = cb;
           return () => {};
         }
       );
 
       // Act
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         callback
       );
-      if (participantEventCallback) {
+
+      // Flush & Simulate
+      await flushMicrotasks();
+      if (runnerEventCallback) {
         // 참가자 이벤트 발생 시뮬레이션
-        await participantEventCallback({
+        await runnerEventCallback({
           type: "updated",
           participant: { ...runner, name: "Updated Name" },
         });
       }
 
-      // Assert
+      // Flush & Assert
+      await flushMicrotasks();
       expect(callback).toHaveBeenCalledTimes(1);
 
       // Cleanup
       unsubscribe();
     });
 
-    it("대회 부문 이벤트(DivisionEvent)가 발생하면 콜백을 호출한다.", async () => {
+    it("대회 부문에 이벤트(DivisionEvent)가 발생하면 콜백을 호출한다.", async () => {
       // Arrange
       const callback = jest.fn();
       let divisionEventCallback: DivisionEventCallback | undefined;
@@ -701,10 +706,13 @@ describe("DivisionProgressService 단위 테스트", () => {
       );
 
       // Act
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         callback
       );
+
+      // Flush & Simulate
+      await flushMicrotasks();
       if (divisionEventCallback) {
         // 대회 부문 이벤트 발생 시뮬레이션
         await divisionEventCallback({
@@ -713,7 +721,8 @@ describe("DivisionProgressService 단위 테스트", () => {
         });
       }
 
-      // Assert
+      // Flush & Assert
+      await flushMicrotasks();
       expect(callback).toHaveBeenCalledTimes(1);
 
       // Cleanup
@@ -723,16 +732,14 @@ describe("DivisionProgressService 단위 테스트", () => {
     it("구독 해제 시 모든 이벤트 구독이 해제된다.", async () => {
       // Arrange
       const unsubscribeDivisionEvent = jest.fn();
-      const unsubscribeParticipantEvent = jest.fn();
       mockCompetitionService.subscribeDivisionEvent.mockReturnValue(
         unsubscribeDivisionEvent
       );
-      mockParticipantService.subscribeParticipantEvent.mockReturnValue(
-        unsubscribeParticipantEvent
-      );
+      const runnerEventEmitter = (service as any).runnerEventEmitter;
+      const offSpy = jest.spyOn(runnerEventEmitter, "off");
 
       // Act
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         jest.fn()
       );
@@ -740,7 +747,10 @@ describe("DivisionProgressService 단위 테스트", () => {
 
       // Assert
       expect(unsubscribeDivisionEvent).toHaveBeenCalledTimes(1);
-      expect(unsubscribeParticipantEvent).toHaveBeenCalledTimes(1);
+      expect(offSpy).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      offSpy.mockRestore();
     });
 
     it("콜백에서 예외가 발생해도 서비스 로직은 계속 동작한다.", async () => {
@@ -753,13 +763,16 @@ describe("DivisionProgressService 단위 테스트", () => {
       const consoleSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      const unsubscribe = await service.subscribeDivisionProgress(
+      const unsubscribe = service.subscribeDivisionProgress(
         division.id,
         errorCallback
       );
 
       // Act
-      const asyncTask = service.setRunner(division.id, runner.id);
+      const asyncTask = service.setRunner(division.id, nextRunner.id);
+
+      // Flush
+      await flushMicrotasks();
 
       // Assert
       await expect(asyncTask).resolves.not.toThrow();
@@ -767,6 +780,34 @@ describe("DivisionProgressService 단위 테스트", () => {
       // Cleanup
       consoleSpy.mockRestore();
       unsubscribe();
+    });
+
+    it("두 명 이상의 구독자에게 경연자 변경 이벤트를 전달한다.", async () => {
+      // Arrange
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+      const unsubscribe1 = service.subscribeDivisionProgress(
+        division.id,
+        callback1
+      );
+      const unsubscribe2 = service.subscribeDivisionProgress(
+        division.id,
+        callback2
+      );
+
+      // Act
+      await service.setRunner(division.id, nextRunner.id);
+
+      // Flush
+      await flushMicrotasks();
+
+      // Assert
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      unsubscribe1();
+      unsubscribe2();
     });
   });
 });


### PR DESCRIPTION
Closes #94 

## 문제 상황

- DivisionProgress 구독 시 가장 최신의 소켓 연결에만 runner 관련 이벤트가 전송되는 문제가 발생함
  - 첫 번째 구독 후 두 번째 구독 시, runner 관련 이벤트를 발생시키면 두 번째 구독에만 이벤트가 전달되는 문제
  - 여러 클라이언트가 동시에 같은 부문을 구독할 때, 마지막 구독자만 이벤트를 받는 상황

## 해결 방법

### 1. EventEmitter 기반 이벤트 전파 시스템 도입

기존의 단일 콜백 방식에서 EventEmitter를 활용한 다중 구독자 지원 방식으로 변경:

```typescript
// 기존: 단일 콜백 저장
private runnerWatcher: Map<string, { callback: DivisionProgressCallback; ... }>

// 개선: EventEmitter를 통한 다중 구독자 지원
private readonly runnerEventEmitter: RunnerEventEmitter = new EventEmitter();
```

### 2. 구독 메커니즘 개선

- **Lazy Watching**: 구독 시점에 경연자 감시 시작하여 불필요한 리소스 사용 방지
- **이벤트 타입 분리**: `runner-event`와 `state-changed` 이벤트를 분리하여 명확한 이벤트 처리
- **구독 해제 로직 개선**: EventEmitter의 `off` 메서드를 활용한 정확한 구독 해제

### 3. 비동기 처리 최적화

- `onStateChanged` 메서드를 동기 처리로 변경하여 이벤트 전파 성능 개선
- `subscribeDivisionProgress` 메서드를 동기 반환으로 변경

## 주요 변경 사항

### `division-progress.ts`
- EventEmitter 기반 `runnerEventEmitter` 도입
- `watchRunner` 메서드로 경연자 이벤트 구독 로직 분리
- `subscribeDivisionProgress` 메서드 구조 개선
- 구독 해제 시 EventEmitter의 `off` 메서드 활용

### `division-progress.actor.ts`
- `subscribeDivisionProgress` 메서드 비동기 제거

### `division-progress.gateway.ts`
- Gateway에서 동기적으로 구독 처리

## 테스트 개선

### 단위 테스트 강화
- `두 명 이상의 구독자에게 경연자 변경 이벤트를 전달한다` 테스트 추가
- 비동기 작업 대기를 위한 `flushMicrotasks` 헬퍼 함수 추가
- EventEmitter 기반 구독 해제 테스트 개선

### Jest 설정 개선
- `testPathIgnorePatterns`에 `build` 디렉터리 추가