### PR TITLE
참가자 벌크 POST API 추가 및 에러 메시지 개선

### DIFF
--- a/server/src/http/bootstrap.ts
+++ b/server/src/http/bootstrap.ts
@@ -5,13 +5,32 @@ import { AppModule } from "./app.module";
 import container from "@/container";
 import { env } from "@/env";
 import { ValidationPipe } from "@nestjs/common";
+import express from "express";
 import { CustomExceptionFilter } from "./exception.filter";
 
 export async function bootstrap() {
   await container.initialize();
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    bodyParser: false,
+  });
+  const expressApp = app.getHttpAdapter().getInstance();
 
   app.setGlobalPrefix("api");
+
+  // JSON 파서 미들웨어 추가
+  expressApp.use(express.json({ limit: "10mb" }));
+
+  // Express 자체 에러 핸들러 추가
+  expressApp.use((error: any, req: any, res: any, next: any) => {
+    if (error instanceof SyntaxError) {
+      return res.status(400).json({
+        statusCode: 400,
+        type: "JsonParseError",
+        message: error.message,
+      });
+    }
+    next(error);
+  });
 
   // Swagger 문서는 development 환경에서만 생성
   if (env.NODE_ENV === "development") {

--- a/server/src/http/controllers/division.controller.ts
+++ b/server/src/http/controllers/division.controller.ts
@@ -29,6 +29,7 @@ import {
 } from "../dtos/division.dto";
 import {
   CreateParticipantDto,
+  CreateParticipantsDto,
   ParticipantResponseDto,
 } from "../dtos/participant.dto";
 import { RecordResponseDto } from "../dtos/record.dto";
@@ -131,6 +132,37 @@ export class DivisionController {
       comment,
       orderRaw
     );
+  }
+
+  @Post("/:divisionId/participants/bulk")
+  @HttpCode(201)
+  @ApiActorSecurity()
+  @ApiResponse({
+    status: 201,
+    description: "참가자 생성 성공 및 생성된 참가자 정보 반환",
+    type: [ParticipantResponseDto],
+  })
+  async createParticipants(
+    @CurrentActor() actor: Actor,
+    @Param("divisionId") divisionId: string,
+    @Body() body: CreateParticipantsDto
+  ): Promise<ParticipantResponseDto[]> {
+    const participants = await Promise.all(
+      body.participants.map(
+        ({ name, teamName, robotName, comment, orderRaw }) => {
+          return this.participantService.addParticipant(
+            actor,
+            divisionId,
+            name,
+            teamName,
+            robotName,
+            comment,
+            orderRaw
+          );
+        }
+      )
+    );
+    return participants;
   }
 
   @Get("/:divisionId/records/top")

--- a/server/src/http/dtos/participant.dto.ts
+++ b/server/src/http/dtos/participant.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { Type } from "class-transformer";
+import {
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
 
 export class ParticipantResponseDto {
   @ApiProperty({ description: "참가자 ID" })
@@ -56,6 +64,14 @@ export class CreateParticipantDto {
   @ApiProperty({ description: "원본 경연 순번", example: 1 })
   @IsNumber()
   orderRaw!: number;
+}
+
+export class CreateParticipantsDto {
+  @ApiProperty({ description: "참가자 목록", type: [CreateParticipantDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateParticipantDto)
+  participants!: CreateParticipantDto[];
 }
 
 export class UpdateParticipantDto {

--- a/server/src/http/exception.filter.ts
+++ b/server/src/http/exception.filter.ts
@@ -41,10 +41,21 @@ export class CustomExceptionFilter implements ExceptionFilter {
     switch (true) {
       case exception instanceof HttpException:
         // Handle NestJS built-in exceptions
+        let message: string = exception.message;
+        const exceptionResponse = exception.getResponse();
+        if (typeof exceptionResponse === "string") {
+          message = exceptionResponse;
+        } else if ("message" in exceptionResponse) {
+          if (typeof exceptionResponse.message === "string") {
+            message = exceptionResponse.message;
+          } else if (Array.isArray(exceptionResponse.message)) {
+            message = exceptionResponse.message.join(", ");
+          }
+        }
         error = {
           statusCode: exception.getStatus(),
           type: exception.constructor.name,
-          message: exception.message,
+          message,
         };
         break;
       case exception instanceof PersistenceError:


### PR DESCRIPTION
## 변경 사항

- `POST /api/divisions/{divisionId}/participants/bulk` API 추가
  - 참가자(Participant)를 한꺼번에 추가할 수 있음!
- Body로 JSON을 보낼 때, 그 형식이 Invalid한 경우, 404 Not Found 에러가 뜨는 문제 해결
  - JSON 파싱 자체는 Express 미들웨어에서 수행되기에 전역 NestJS 에러 필터를 거치지 않음.
  - 따라서 Express에서 발생한 에러를 처리하는 미들웨어를 따로 두어 에러 응답을 바로 반환하도록 함.
    ```sh
    curl -X 'POST' \
      'http://localhost:3000/api/actors/login' \
      -H 'accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{this is invalid json!!!}'
    ```
    ```
    {
      "statusCode": 400,
      "type": "JsonParseError",
      "message": "Expected property name or '}' in JSON at position 1 (line 1 column 2)"
    }
    ```
- Body DTO 검증 시 어느 부분이 문제인지에 대한 에러 메시지를 자세히 출력하도록 변경
  - 검증 실패 시 아래와 같이 자세한 메시지가 출력됨.
    ```sh
    curl -X 'POST' \
      'http://localhost:3000/api/actors/login' \
      -H 'accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{
      "name": "gd-hong",
      "password": "super-secret",
      "invalidfield": "wow"
    }'
    ```
    ```
    {
      "statusCode": 400,
      "type": "BadRequestException",
      "message": "property name should not exist, property invalidfield should not exist, username should not be empty, username must be a string"
    }
    ```