### PR TITLE
계수기 Timeout 설정 가능하게 변경 및 HTTP Keep-Alive 적용

### DIFF
--- a/counters/rpi-counter-sensor/config.example.json
+++ b/counters/rpi-counter-sensor/config.example.json
@@ -7,5 +7,6 @@
   "spi_device_path": "/dev/spidev0.0",
   "api_base_url": "https://counter.zetin.uos.ac.kr/api",
   "api_username": "gd-hong",
-  "api_password": "super-secret"
+  "api_password": "super-secret",
+  "api_http_timeout": 5
 }

--- a/counters/rpi-counter-sensor/src/config.cpp
+++ b/counters/rpi-counter-sensor/src/config.cpp
@@ -26,6 +26,7 @@ Config Config::load_from_file(const std::string& file_path) {
     config.api_base_url = j["api_base_url"];
     config.api_username = j["api_username"];
     config.api_password = j["api_password"];
+    config.api_http_timeout = j["api_http_timeout"];
     
     return config;
 }

--- a/counters/rpi-counter-sensor/src/config.hpp
+++ b/counters/rpi-counter-sensor/src/config.hpp
@@ -16,6 +16,7 @@ struct Config {
     std::string api_base_url;
     std::string api_username;
     std::string api_password;
+    uint32_t api_http_timeout; // seconds
     
     static Config load_from_file(const std::string& file_path);
 };

--- a/counters/rpi-counter-sensor/src/http_curl_client.cpp
+++ b/counters/rpi-counter-sensor/src/http_curl_client.cpp
@@ -23,9 +23,9 @@ bool HttpResponse::is_ok() const {
     return status_code_ >= 200 && status_code_ < 300;
 }
 
-// ┌───────────────────┐
-// │ HttpCurlException │
-// └───────────────────┘
+// ┌───────────────┐
+// │ CurlException │
+// └───────────────┘
 
 CurlException::CurlException(const std::string& message, CURLcode curl_code, const std::string& url)
     : std::runtime_error(message), curl_code_(curl_code), url_(url) {}
@@ -45,19 +45,19 @@ const std::string& CurlException::get_url() const {
 bool HttpCurlClient::curl_initialized_ = false;
 
 size_t HttpCurlClient::write_callback(void* buffer, size_t size, size_t nmemb, void* userp) {
-    HttpCurlClient* client = static_cast<HttpCurlClient*>(userp);
-    if (!client) {
+    std::vector<uint8_t>* response_data = static_cast<std::vector<uint8_t>*>(userp);
+    if (!response_data) {
         return 0;
     }
 
     size_t real_size = size * nmemb;
     const uint8_t* data = static_cast<const uint8_t*>(buffer);
-    client->response_data_.insert(client->response_data_.end(), data, data + real_size);
+    response_data->insert(response_data->end(), data, data + real_size);
 
     return real_size;
 }
 
-HttpCurlClient::HttpCurlClient(bool ssl_verify) {
+HttpCurlClient::HttpCurlClient(const HttpCurlClientConfig& config) : config_(config) {
     if (!curl_initialized_) {
         curl_global_init(CURL_GLOBAL_DEFAULT);
         curl_initialized_ = true;
@@ -67,78 +67,88 @@ HttpCurlClient::HttpCurlClient(bool ssl_verify) {
     if (!curl_) {
         throw std::runtime_error("Failed to initialize CURL");
     }
-    header_list_ = nullptr;
-    http_status_code_ = 0;
 
-    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, ssl_verify ? 1L : 0L);
-    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYHOST, ssl_verify ? 2L : 0L);
+    // SSL 설정
+    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, config.ssl_verify ? 1L : 0L);
+    curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYHOST, config.ssl_verify ? 2L : 0L);
+
+    // Keep-Alive 설정
+    if (config.keep_alive) {
+        curl_easy_setopt(curl_, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+        curl_easy_setopt(curl_, CURLOPT_TCP_KEEPALIVE, 1L);
+        curl_easy_setopt(curl_, CURLOPT_TCP_KEEPIDLE, 120L);
+        curl_easy_setopt(curl_, CURLOPT_TCP_KEEPINTVL, 60L);
+    }
 }
 
 HttpCurlClient::~HttpCurlClient() {
     if (curl_) {
         curl_easy_cleanup(curl_);
     }
-    if (header_list_) {
-        curl_slist_free_all(header_list_);
+}
+
+HttpCurlClient::HttpCurlClient(HttpCurlClient&& other)
+    : config_(std::move(other.config_)), curl_(other.curl_) {
+    other.curl_ = nullptr;
+}
+
+HttpCurlClient& HttpCurlClient::operator=(HttpCurlClient&& other) {
+    if (this != &other) {
+        config_ = std::move(other.config_);
+        curl_ = other.curl_;
+        other.curl_ = nullptr;
     }
+    return *this;
 }
 
-HttpCurlClient& HttpCurlClient::reset() {
-    if (curl_) {
-        curl_easy_reset(curl_);
+HttpResponse HttpCurlClient::request(const HttpCurlRequest& request) {
+    // URL 설정
+    curl_easy_setopt(curl_, CURLOPT_URL, request.url.c_str());
+
+    // HTTP 메서드 설정
+    curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, request.method.c_str());
+
+    // 헤더 설정
+    CurlHeaderList headers;
+    for (const auto& [key, value] : request.headers) {
+        headers.append(key + ": " + value);
     }
-    if (header_list_) {
-        curl_slist_free_all(header_list_);
-        header_list_ = nullptr;
+    if (config_.keep_alive) { // keep-alive 헤더 추가
+        headers.append("Connection: keep-alive");
     }
-    response_data_.clear();
-    http_status_code_ = 0;
-    current_url_.clear();
-    return *this;
-}
-
-HttpCurlClient& HttpCurlClient::set_url(const std::string& url) {
-    current_url_ = url;
-    curl_easy_setopt(curl_, CURLOPT_URL, current_url_.c_str());
-    return *this;
-}
-
-HttpCurlClient& HttpCurlClient::set_method(const std::string& method) {
-    curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, method.c_str());
-    return *this;
-}
-
-HttpCurlClient& HttpCurlClient::set_headers(const std::vector<std::pair<std::string, std::string>>& headers) {
-    for (const auto &header : headers) {
-        header_list_ = curl_slist_append(header_list_, (header.first + ": " + header.second).c_str());
+    if (headers.get()) {
+        curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers.get());
     }
-    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, header_list_);
-    return *this;
-}
 
-HttpCurlClient& HttpCurlClient::set_body(const std::string& body) {
-    curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, body.c_str());
-    return *this;
-}
+    // Body 설정
+    if (!request.body.empty()) {
+        curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, request.body.data());
+        curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, request.body.size());
+    }
 
-HttpCurlClient& HttpCurlClient::set_timeout(int timeout_seconds, int connect_timeout_seconds) {
-    curl_easy_setopt(curl_, CURLOPT_TIMEOUT, timeout_seconds);
-    curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, connect_timeout_seconds);
-    return *this;
-}
+    // 타임아웃 설정
+    if (request.timeout_seconds > 0) {
+        curl_easy_setopt(curl_, CURLOPT_TIMEOUT, request.timeout_seconds);
+    }
 
-HttpResponse HttpCurlClient::execute() {
-    response_data_.clear();
-    http_status_code_ = 0;
+    // 응답 데이터 저장을 위한 버퍼
+    std::vector<uint8_t> response_data;
 
+    // 콜백 설정
     curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, write_callback);
-    curl_easy_setopt(curl_, CURLOPT_WRITEDATA, this);
+    curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response_data);
 
+    // 요청 실행
     CURLcode result = curl_easy_perform(curl_);
+
+    // 에러 확인
     if (result != CURLE_OK) {
-        throw CurlException(curl_easy_strerror(result), result, current_url_);
+        throw CurlException(curl_easy_strerror(result), result, request.url);
     }
 
-    curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &http_status_code_);
-    return HttpResponse(http_status_code_, response_data_);
+    // HTTP 상태 코드 가져오기
+    long http_status_code = 0;
+    curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &http_status_code);
+
+    return HttpResponse(static_cast<int>(http_status_code), response_data);
 }

--- a/counters/rpi-counter-sensor/src/http_curl_client.cpp
+++ b/counters/rpi-counter-sensor/src/http_curl_client.cpp
@@ -94,6 +94,9 @@ HttpCurlClient::HttpCurlClient(HttpCurlClient&& other)
 
 HttpCurlClient& HttpCurlClient::operator=(HttpCurlClient&& other) {
     if (this != &other) {
+        if (curl_) {
+            curl_easy_cleanup(curl_); // 기존 curl 핸들 정리
+        }
         config_ = std::move(other.config_);
         curl_ = other.curl_;
         other.curl_ = nullptr;

--- a/counters/rpi-counter-sensor/src/http_curl_client.hpp
+++ b/counters/rpi-counter-sensor/src/http_curl_client.hpp
@@ -32,32 +32,61 @@ public:
     const std::string& get_url() const;
 };
 
+struct HttpCurlClientConfig {
+    bool ssl_verify = true;
+    bool keep_alive = false;
+};
+
+struct HttpCurlRequest {
+    std::string url;
+    std::string method;
+    std::vector<std::pair<std::string, std::string>> headers;
+    std::vector<uint8_t> body;
+    uint32_t timeout_seconds = 0;
+};
+
 class HttpCurlClient {
 private:
     static bool curl_initialized_;
     CURL* curl_;
-    struct curl_slist* header_list_;
-    std::vector<uint8_t> response_data_;
-    long http_status_code_;
-    std::string current_url_;
+    HttpCurlClientConfig config_;
 
     static size_t write_callback(void* buffer, size_t size, size_t nmemb, void* userp);
 
+    class CurlHeaderList {
+    private:
+        struct curl_slist* list_;
+        
+    public:
+        CurlHeaderList() : list_(nullptr) {}
+        ~CurlHeaderList() {
+            if (list_) {
+                curl_slist_free_all(list_);
+            }
+        }
+        
+        void append(const std::string& header) {
+            list_ = curl_slist_append(list_, header.c_str());
+        }
+        struct curl_slist* get() const {
+            return list_;
+        }
+        
+        CurlHeaderList(const CurlHeaderList&) = delete;
+        CurlHeaderList& operator=(const CurlHeaderList&) = delete;
+        CurlHeaderList(CurlHeaderList&&) = delete;
+        CurlHeaderList& operator=(CurlHeaderList&&) = delete;
+    };
+
 public:
-    HttpCurlClient(bool ssl_verify = true);
+    HttpCurlClient(const HttpCurlClientConfig& config = HttpCurlClientConfig());
     ~HttpCurlClient();
 
-    HttpCurlClient& reset();
-    HttpCurlClient& set_url(const std::string& url);
-    HttpCurlClient& set_method(const std::string& method);
-    HttpCurlClient& set_headers(const std::vector<std::pair<std::string, std::string>>& headers);
-    HttpCurlClient& set_body(const std::string& body);
-    HttpCurlClient& set_timeout(int timeout_seconds, int connect_timeout_seconds);
-    HttpResponse execute();
+    HttpResponse request(const HttpCurlRequest& request);
 
-    HttpCurlClient(const HttpCurlClient&) noexcept = delete;
-    HttpCurlClient& operator=(const HttpCurlClient&) noexcept = delete;
+    HttpCurlClient(const HttpCurlClient&) = delete;
+    HttpCurlClient& operator=(const HttpCurlClient&) = delete;
 
-    HttpCurlClient(HttpCurlClient&&) noexcept = delete;
-    HttpCurlClient& operator=(HttpCurlClient&&) noexcept = delete;
+    HttpCurlClient(HttpCurlClient&&);
+    HttpCurlClient& operator=(HttpCurlClient&&);
 };

--- a/counters/rpi-counter-sensor/src/http_sensor_data_sender.cpp
+++ b/counters/rpi-counter-sensor/src/http_sensor_data_sender.cpp
@@ -12,22 +12,22 @@ using json = nlohmann::json;
 
 std::string HttpSensorDataSender::login(const std::string& username, const std::string& password) {
     try {
-        json request_body = {
+        json body_json = {
             { "username", username },
             { "password", password }
         };
+        std::string body_str = body_json.dump();
 
-        HttpCurlClient client;
-        HttpResponse res = client
-            .set_url(api_base_url_ + "/actors/login")
-            .set_method("POST")
-            .set_headers({
+        HttpResponse res = client_.request(HttpCurlRequest{
+            .url = api_base_url_ + "/actors/login",
+            .method = "POST",
+            .headers = {
                 { "Content-Type", "application/json" }
-            })
-            .set_body(request_body.dump())
-            .set_timeout(api_http_timeout_, api_http_timeout_)
-            .execute();
-        
+            },
+            .body = std::vector<uint8_t>(body_str.begin(), body_str.end()),
+            .timeout_seconds = api_http_timeout_,
+        });
+
         if (res.is_ok()) {
             return res.get_text();
         } else {
@@ -40,15 +40,14 @@ std::string HttpSensorDataSender::login(const std::string& username, const std::
 
 void HttpSensorDataSender::logout() {
     try {
-        HttpCurlClient client;
-        HttpResponse res = client
-            .set_url(api_base_url_ + "/actors/logout")
-            .set_method("POST")
-            .set_headers({
+        HttpResponse res = client_.request(HttpCurlRequest{
+            .url = api_base_url_ + "/actors/logout",
+            .method = "POST",
+            .headers = {
                 { "Authorization", "Session " + session_key_ }
-            })
-            .set_timeout(api_http_timeout_, api_http_timeout_)
-            .execute();
+            },
+            .timeout_seconds = api_http_timeout_,
+        });
 
         if (!res.is_ok()) {
             throw SenderException("Failed to logout: " + res.get_text());
@@ -60,25 +59,25 @@ void HttpSensorDataSender::logout() {
 
 void HttpSensorDataSender::register_device(const DeviceInfo& device_info) {    
     try {
-        json request_body = {
+        json body_json = {
             { "deviceId", device_info.device_id },
             { "name", device_info.name },
             { "startThreshold", device_info.start_threshold },
             { "endThreshold", device_info.end_threshold },
             { "endDebouncingTime", device_info.end_debouncing_time }
         };
+        std::string body_str = body_json.dump();
 
-        HttpCurlClient client;
-        HttpResponse res = client
-            .set_url(api_base_url_ + "/counters/front-back-ir/register")
-            .set_method("POST")
-            .set_headers({
+        HttpResponse res = client_.request(HttpCurlRequest{
+            .url = api_base_url_ + "/counters/front-back-ir/register",
+            .method = "POST",
+            .headers = {
                 { "Content-Type", "application/json" },
                 { "Authorization", "Session " + session_key_ }
-            })
-            .set_body(request_body.dump())
-            .set_timeout(api_http_timeout_, api_http_timeout_)
-            .execute();
+            },
+            .body = std::vector<uint8_t>(body_str.begin(), body_str.end()),
+            .timeout_seconds = api_http_timeout_,
+        });
 
         if (!res.is_ok()) {
             throw SenderException("Failed to register device: " + res.get_text());
@@ -90,15 +89,14 @@ void HttpSensorDataSender::register_device(const DeviceInfo& device_info) {
 
 void HttpSensorDataSender::unregister_device(const std::string& device_id) {
     try {
-        HttpCurlClient client;
-        HttpResponse res = client
-            .set_url(api_base_url_ + "/counters/" + device_id)
-            .set_method("DELETE")
-            .set_headers({
+        HttpResponse res = client_.request(HttpCurlRequest{
+            .url = api_base_url_ + "/counters/" + device_id,
+            .method = "DELETE",
+            .headers = {
                 { "Authorization", "Session " + session_key_ }
-            })
-            .set_timeout(api_http_timeout_, api_http_timeout_)
-            .execute();
+            },
+            .timeout_seconds = api_http_timeout_,
+        });
 
         if (!res.is_ok()) {
             throw SenderException("Failed to unregister device: " + res.get_text());
@@ -114,21 +112,21 @@ void HttpSensorDataSender::send_data(const std::string& device_id, const std::ve
         for (const auto &item : data) {
             data_json.push_back({ item.timestamp, item.front_ir, item.back_ir });
         }
-        json request_body = {
+        json body_json = {
             { "data", data_json }
         };
+        std::string body_str = body_json.dump();
 
-        HttpCurlClient client;
-        HttpResponse res = client
-            .set_url(api_base_url_ + "/counters/front-back-ir/" + device_id + "/data")
-            .set_method("PUT")
-            .set_headers({
+        HttpResponse res = client_.request(HttpCurlRequest{
+            .url = api_base_url_ + "/counters/front-back-ir/" + device_id + "/data",
+            .method = "PUT",
+            .headers = {
                 { "Content-Type", "application/json" },
                 { "Authorization", "Session " + session_key_ }
-            })
-            .set_body(request_body.dump())
-            .set_timeout(api_http_timeout_, api_http_timeout_)
-            .execute();
+            },
+            .body = std::vector<uint8_t>(body_str.begin(), body_str.end()),
+            .timeout_seconds = api_http_timeout_,
+        });
 
         if (!res.is_ok()) {
             throw SenderException("Failed to send data: " + res.get_text());
@@ -144,11 +142,16 @@ HttpSensorDataSender::HttpSensorDataSender(
     const std::string& password,
     const uint32_t api_http_timeout,
     const DeviceInfo& device_info
-): api_base_url_(api_base_url)
-    , username_(username)
-    , password_(password)
-    , api_http_timeout_(api_http_timeout)
-    , device_info_(device_info) {}
+) : api_base_url_(api_base_url),
+    username_(username),
+    password_(password),
+    api_http_timeout_(api_http_timeout),
+    device_info_(device_info) {
+    client_ = std::move(HttpCurlClient(HttpCurlClientConfig{
+        .ssl_verify = true,
+        .keep_alive = true,
+    }));
+}
 
 HttpSensorDataSender::~HttpSensorDataSender() {
     if (!session_key_.empty()) {

--- a/counters/rpi-counter-sensor/src/http_sensor_data_sender.cpp
+++ b/counters/rpi-counter-sensor/src/http_sensor_data_sender.cpp
@@ -25,7 +25,7 @@ std::string HttpSensorDataSender::login(const std::string& username, const std::
                 { "Content-Type", "application/json" }
             })
             .set_body(request_body.dump())
-            .set_timeout(2, 2)
+            .set_timeout(api_http_timeout_, api_http_timeout_)
             .execute();
         
         if (res.is_ok()) {
@@ -47,7 +47,7 @@ void HttpSensorDataSender::logout() {
             .set_headers({
                 { "Authorization", "Session " + session_key_ }
             })
-            .set_timeout(2, 2)
+            .set_timeout(api_http_timeout_, api_http_timeout_)
             .execute();
 
         if (!res.is_ok()) {
@@ -77,7 +77,7 @@ void HttpSensorDataSender::register_device(const DeviceInfo& device_info) {
                 { "Authorization", "Session " + session_key_ }
             })
             .set_body(request_body.dump())
-            .set_timeout(2, 2)
+            .set_timeout(api_http_timeout_, api_http_timeout_)
             .execute();
 
         if (!res.is_ok()) {
@@ -97,7 +97,7 @@ void HttpSensorDataSender::unregister_device(const std::string& device_id) {
             .set_headers({
                 { "Authorization", "Session " + session_key_ }
             })
-            .set_timeout(2, 2)
+            .set_timeout(api_http_timeout_, api_http_timeout_)
             .execute();
 
         if (!res.is_ok()) {
@@ -127,7 +127,7 @@ void HttpSensorDataSender::send_data(const std::string& device_id, const std::ve
                 { "Authorization", "Session " + session_key_ }
             })
             .set_body(request_body.dump())
-            .set_timeout(1, 1)
+            .set_timeout(api_http_timeout_, api_http_timeout_)
             .execute();
 
         if (!res.is_ok()) {
@@ -142,8 +142,13 @@ HttpSensorDataSender::HttpSensorDataSender(
     const std::string& api_base_url,
     const std::string& username,
     const std::string& password,
+    const uint32_t api_http_timeout,
     const DeviceInfo& device_info
-) : api_base_url_(api_base_url), username_(username), password_(password), device_info_(device_info) {}
+): api_base_url_(api_base_url)
+    , username_(username)
+    , password_(password)
+    , api_http_timeout_(api_http_timeout)
+    , device_info_(device_info) {}
 
 HttpSensorDataSender::~HttpSensorDataSender() {
     if (!session_key_.empty()) {

--- a/counters/rpi-counter-sensor/src/http_sensor_data_sender.hpp
+++ b/counters/rpi-counter-sensor/src/http_sensor_data_sender.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "interfaces.hpp"
+#include "http_curl_client.hpp"
 #include <string>
 #include <vector>
 
@@ -19,8 +20,9 @@ private:
 
     DeviceInfo device_info_;
     std::string session_key_;
-    bool registered_device_ = false;
+    HttpCurlClient client_;
 
+    bool registered_device_ = false;
     bool have_to_reconnect_ = false;
 
     std::string login(const std::string& username, const std::string& password);

--- a/counters/rpi-counter-sensor/src/http_sensor_data_sender.hpp
+++ b/counters/rpi-counter-sensor/src/http_sensor_data_sender.hpp
@@ -15,6 +15,7 @@ private:
     std::string username_;
     std::string password_;
     std::string api_base_url_;
+    uint32_t api_http_timeout_; // seconds
 
     DeviceInfo device_info_;
     std::string session_key_;
@@ -33,6 +34,7 @@ public:
         const std::string& api_base_url,
         const std::string& username,
         const std::string& password,
+        const uint32_t api_http_timeout,
         const DeviceInfo& device_info
     );
 

--- a/counters/rpi-counter-sensor/src/main.cpp
+++ b/counters/rpi-counter-sensor/src/main.cpp
@@ -128,6 +128,7 @@ int main(int argc, char* argv[]) {
         config.api_base_url,
         config.api_username,
         config.api_password,
+        config.api_http_timeout,
         device_info
     );
 

--- a/counters/rpi-counter-sensor/src/main.cpp
+++ b/counters/rpi-counter-sensor/src/main.cpp
@@ -42,7 +42,7 @@ void thread_read_sensor_data(ISensorDataReader& reader, ThreadSafeQueue<SensorDa
         if (log_elapsed_time >= log_interval) {
             double avg_read_count = (double)log_read_count / std::chrono::duration_cast<std::chrono::seconds>(log_elapsed_time).count();
             Logger::log(
-                "Avg read count: ", avg_read_count, " items/s",
+                "[RX] Avg read count: ", avg_read_count, " items/s",
                 ", Avg jitter: ", timer.get_average_jitter(), " us");
             last_log_time = std::chrono::steady_clock::now();
             log_read_count = 0;
@@ -56,6 +56,7 @@ void thread_send_sensor_data(ISensorDataSender& sender, ThreadSafeQueue<SensorDa
     auto last_log_time = std::chrono::steady_clock::now();
     const auto log_interval = std::chrono::seconds(2);
     int log_send_count = 0;
+    int log_send_error_count = 0;
 
     while (keep_running) {
         // 데이터 배치 가져오기
@@ -66,9 +67,13 @@ void thread_send_sensor_data(ISensorDataSender& sender, ThreadSafeQueue<SensorDa
             try {
                 sender.send_sensor_data(data_batch);
                 log_send_count += data_batch.size();
+                log_send_error_count = 0;
             } catch (const std::exception& e) {
-                Logger::error("Error sending sensor data: ", e.what());
-                std::this_thread::sleep_for(std::chrono::seconds(1));
+                Logger::error("[TX] Error sending sensor data: ", e.what());
+                log_send_error_count++;
+                int wait_seconds = std::min(log_send_error_count, 5);
+                Logger::error("[TX] Waiting for ", wait_seconds, " seconds before next try...");
+                std::this_thread::sleep_for(std::chrono::seconds(wait_seconds));
             }
         }
 
@@ -79,8 +84,8 @@ void thread_send_sensor_data(ISensorDataSender& sender, ThreadSafeQueue<SensorDa
         const auto log_elapsed_time = std::chrono::steady_clock::now() - last_log_time;
         if (log_elapsed_time >= log_interval) {
             double avg_send_count = (double)log_send_count / std::chrono::duration_cast<std::chrono::seconds>(log_elapsed_time).count();
-            Logger::log("Avg send count: ", avg_send_count, " items/s"
-                ", Avg jitter: ", timer.get_average_jitter() / 1000.0, " ms");
+            Logger::log("[TX] Avg send count: ", avg_send_count, " items/s"
+                ", Avg jitter: ", timer.get_average_jitter(), " us");
             last_log_time = std::chrono::steady_clock::now();
             log_send_count = 0;
         }


### PR DESCRIPTION
## 변경 사항

- 계수기 시스템 소프트웨어에서 HTTP 요청 시 Timeout 시간을 설정 가능하게 변경(config 파일에 `api_http_timeout` 필드 추가)
- 계수기 시스템 소프트웨어의 HttpCurlClient의 메서드를 간소화함. `set_` 류 함수들을 제거하고 `request` 함수만 두고 매개변수로 url, method, header 등을 설정할 수 있도록 변경
- 계수기 시스템 소프트웨어의 HttpCurlClient에서 HTTP Keep-Alive를 사용할 수 있도록 변경. 덕분에 초기 커넥션 시간이 짧아지고 전송 레이턴시가 크게 감소함.