### PR TITLE
Counter hotfix 적용

### DIFF
--- a/client/src/pages/manual-counter/ui/manual-counter-page.tsx
+++ b/client/src/pages/manual-counter/ui/manual-counter-page.tsx
@@ -149,12 +149,12 @@ export function ManualCounter() {
             </div>
 
             {/* Control Buttons */}
-            <div className="flex flex-col sm:flex-row justify-center gap-4 sm:gap-6 md:gap-6 mb-6 sm:mb-8 md:mb-10">
+            <div className="grid grid-cols-2 gap-4 sm:gap-6 md:gap-6 mb-6 sm:mb-8 md:mb-10">
               <Button
                 onClick={handleStart}
                 disabled={isRunning}
                 size="lg"
-                className="w-full sm:w-auto px-6 py-3 sm:px-8 sm:py-4 md:px-10 md:py-5 bg-green-500 text-white font-bold text-base sm:text-lg md:text-lg lg:text-lg hover:bg-green-600"
+                className="h-32 text-center bg-green-500 text-white font-bold text-base sm:text-lg md:text-lg lg:text-lg hover:bg-green-600"
               >
                 시작
               </Button>
@@ -162,10 +162,12 @@ export function ManualCounter() {
                 onClick={handleStop}
                 disabled={!isRunning}
                 size="lg"
-                className="w-full sm:w-auto px-6 py-3 sm:px-8 sm:py-4 md:px-10 md:py-5 bg-red-500 text-white font-bold text-base sm:text-lg md:text-lg lg:text-lg hover:bg-red-600"
+                className="h-32 text-center bg-red-500 text-white font-bold text-base sm:text-lg md:text-lg lg:text-lg hover:bg-red-600"
               >
                 정지
               </Button>
+            </div>
+            <div>
               <Button
                 onClick={handleReset}
                 disabled={isRunning}

--- a/client/src/pages/timer/ui/division-info.tsx
+++ b/client/src/pages/timer/ui/division-info.tsx
@@ -1,36 +1,20 @@
-import { useCounterService } from "@/features/counter";
 import { useProgressService } from "@/features/progress";
 
-interface DivisionInfoProps {
-  counterId: string;
-}
-
-export function DivisionInfo({ counterId }: DivisionInfoProps) {
-  const counterService = useCounterService();
+export function DivisionInfo() {
   const progressService = useProgressService();
-  const counter = counterService.use.counterState(counterId);
   const division = progressService.use.division();
-
   const divisionName = division?.name || "No Division";
-  const stopwatchName = counter?.name || "No Stopwatch";
 
   return (
-    <div className="flex flex-col items-center justify-between w-full">
+    <div className="w-full h-full flex items-center justify-center">
       <div
         className="
           text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-8xl
-          font-bold tracking-tight text-center text-foreground
-          mb-6 break-keep
+          font-bold tracking-tight text-center text-foreground break-keep
         "
         title="Division Name"
       >
         {divisionName}
-      </div>
-      <div
-        className="text-xs sm:text-sm md:text-base lg:text-lg xl:text-xl 2xl:text-3xl font-medium text-muted-foreground"
-        title="Stopwatch Name"
-      >
-        계수기: {stopwatchName}
       </div>
     </div>
   );

--- a/client/src/pages/timer/ui/runner-info.tsx
+++ b/client/src/pages/timer/ui/runner-info.tsx
@@ -40,8 +40,8 @@ export function RunnerInfo() {
   }, [displayText, displayTextClassName]);
 
   return (
-    <div className="flex flex-col items-center justify-center w-full">
-      <div ref={containerRef} className="w-full mb-1 overflow-hidden whitespace-nowrap">
+    <div className="w-full h-full flex flex-col items-center justify-center">
+      <div ref={containerRef} className="w-full overflow-hidden whitespace-nowrap">
         {shouldAnimate ? (
           <Marquee
             speed={128}

--- a/client/src/pages/timer/ui/timer-page.tsx
+++ b/client/src/pages/timer/ui/timer-page.tsx
@@ -86,9 +86,9 @@ export function TimerPage() {
       <TimerPageHeader />
       <section id="timer-content" className="flex-1 min-h-0 overflow-hidden p-8">
         <div className="grid grid-rows-[auto_1fr] min-h-0 h-full gap-8">
-          <div className="shrink-0 grid grid-cols-2 gap-6">
+          <div className="shrink-0 grid grid-cols-2">
             <div>
-              <DivisionInfo counterId={counterId} />
+              <DivisionInfo />
             </div>
             <div>
               <RunnerInfo />

--- a/client/src/pages/timer/ui/top-record-info.tsx
+++ b/client/src/pages/timer/ui/top-record-info.tsx
@@ -149,12 +149,14 @@ export function TopRecordView() {
                 title={right ? `${right.participantName} - ${formatElapsedMs(right.timeMs).toString()}s` : undefined}
               >
                 {right ? (
-                  <div className="text-center leading-none">
-                    <div className="text-md sm:text-lg md:text-xl lg:text-2xl xl:text-3xl 2xl:text-4xl font-bold">
+                  <div className="w-full h-full flex flex-col items-center justify-center leading-none text-center text-sm sm:text-sm md:text-md lg:text-lg xl:text-xl 2xl:text-4xl">
+                    <div className="font-bold">
+                      {right.participantName}
+                      <span className="mx-0.5">·</span>
                       {formatElapsedMs(right.timeMs).toString()}s
                     </div>
-                    <div className="text-sm sm:text-md md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl text-muted-foreground truncate">
-                      {right.participantName}
+                    <div className="mt-1 text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap max-w-full">
+                      {right.participantTeamName}
                     </div>
                   </div>
                 ) : (

--- a/client/src/pages/timer/ui/top-record-info.tsx
+++ b/client/src/pages/timer/ui/top-record-info.tsx
@@ -107,21 +107,17 @@ export function TopRecordView() {
                 {rowIdx + 1}
               </span>
               <span
-                className={cn(
-                  "flex items-center justify-center",
-                  rankBg(leftRank) || `${bgLeft} text-foreground`,
-                  isLeftTopRank && "font-bold"
-                )}
+                className={cn(rankBg(leftRank) || `${bgLeft} text-foreground`, isLeftTopRank && "font-bold")}
                 title={left ? `${left.participantName} - ${formatElapsedMs(left.timeMs).toString()}s` : undefined}
               >
                 {left ? (
-                  <div className="text-center leading-none">
-                    <div className="text-md sm:text-lg md:text-xl lg:text-2xl xl:text-3xl 2xl:text-4xl font-bold">
+                  <div className="w-full h-full flex flex-col items-center justify-center leading-none text-center text-sm sm:text-sm md:text-md lg:text-lg xl:text-xl 2xl:text-4xl">
+                    <div className="font-bold">
                       {left.participantName}
                       <span className="mx-0.5">·</span>
                       {formatElapsedMs(left.timeMs).toString()}s
                     </div>
-                    <div className="text-sm sm:text-sm md:text-md lg:text-lg xl:text-xl 2xl:text-2xl text-muted-foreground truncate">
+                    <div className="mt-1 text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap max-w-full">
                       {left.participantTeamName}
                     </div>
                   </div>

--- a/counters/rpi-counter-sensor/src/bpw34_sensor_data_reader.cpp
+++ b/counters/rpi-counter-sensor/src/bpw34_sensor_data_reader.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/spi/spidev.h>
+#include <algorithm>
 
 // ┌───────────────────────┐
 // │ Bpw34SensorDataReader │
@@ -80,11 +81,19 @@ SensorDataItem Bpw34SensorDataReader::read_sensor_data() {
     uint64_t timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()
     ).count();
-    uint16_t front_ir_raw = (read_adc(0) + read_adc(1)) / 2;
-    uint16_t back_ir_raw = (read_adc(2) + read_adc(3)) / 2;
+    uint16_t sensor_data_raw[4] = {
+        read_adc(0),
+        read_adc(1),
+        read_adc(2),
+        read_adc(3)
+    };
 
-    uint8_t front_ir = static_cast<uint8_t>(front_ir_raw >> 2);
-    uint8_t back_ir = static_cast<uint8_t>(back_ir_raw >> 2);
+    uint8_t front_ir = static_cast<uint8_t>(
+        std::max(sensor_data_raw[0], sensor_data_raw[1]) >> 2
+    );
+    uint8_t back_ir = static_cast<uint8_t>(
+        std::max(sensor_data_raw[2], sensor_data_raw[3]) >> 2
+    );
 
     return SensorDataItem{
         .timestamp = timestamp,


### PR DESCRIPTION
2025-08-16 대회 운영 중 발생한 개선사항 적용 건을 올립니다.

- [계수기 H/W] 센서 데이터 읽기 로직 수정
  - 센서가 여러 개 있을 때 최댓값을 선택하기로 변경
- [Frontend] DivisionInfo 컴포넌트에서 계수기에 대한 정보 표시 제거
- [Frontend] 타이머 뷰 글자 크기 및 컨테이너 크기 맞춤
- [Frontend] 타이머 뷰에서 최고 기록에 팀 이름도 나오도록 수정했는데, 오른쪽 패널에는 적용하지 않았던 문제 해결
- [Frontend] 수동 계수 페이지에서 '시작', '중지'를 더욱 크게 만들고 좌우로 배치하여 누르기 쉽게 만듦